### PR TITLE
make camera flip image instead of code to save some cpu

### DIFF
--- a/src/psmoveservice/Device/View/ServerTrackerView.cpp
+++ b/src/psmoveservice/Device/View/ServerTrackerView.cpp
@@ -381,8 +381,7 @@ public:
     {
         const cv::Mat videoBufferMat(frameHeight, frameWidth, CV_8UC3, const_cast<unsigned char *>(video_buffer));
 
-        // Copy and Flip image about the x-axis
-        cv::flip(videoBufferMat, *bgrBuffer, 1);
+		videoBufferMat.copyTo(*bgrBuffer);
 
         // Convert the video buffer to the HSV color space
 		if (bgr2hsv != nullptr)

--- a/src/psmoveservice/PSMoveTracker/PSEye/PSEyeVideoCapture.cpp
+++ b/src/psmoveservice/PSMoveTracker/PSEye/PSEyeVideoCapture.cpp
@@ -405,6 +405,8 @@ protected:
                 
                 eye->setAutogain(false);
                 eye->setAutoWhiteBalance(false);
+
+				eye->setFlip(true, false);
                 
                 m_index = _index;
                 refreshDimensions();


### PR DESCRIPTION
on my tests with delay_thread=0 to see higher utilisation I went down
from 53 to 48 % of cpu utilisation on 4eye3controler setup

i don't think it should be parametrized cause it is really easy to verify by few people and we should simply forget old code.