### PR TITLE
PSNaviController buffer overrun fix

### DIFF
--- a/src/psmoveservice/PSNaviController/PSNaviController.cpp
+++ b/src/psmoveservice/PSNaviController/PSNaviController.cpp
@@ -18,7 +18,7 @@
 //###bwalker $TODO This haven't been tested yet
 #define PSNAVI_BTADDR_GET_SIZE 16
 #define PSNAVI_BTADDR_SIZE 6
-#define PSNAVI_BTADDR_SET_SIZE 7
+#define PSNAVI_BTADDR_SET_SIZE 10
 #define PSNAVI_STATE_BUFFER_MAX 16
 
 //###bwalker $TODO This haven't been tested yet


### PR DESCRIPTION
I just spotted this while going through the code.

PSNAVI_BTADDR_SET_SIZE is 7.

in setHostBluetoothAddress() you have:
    unsigned char bts[PSNAVI_BTADDR_SET_SIZE];
    unsigned char addr[6];
        memcpy(&bts[3], addr, sizeof(addr));

which means you're copying 6 bytes into position 4 of a 7 byte buffer.

I'm not terribly sure that this is the right way of "fixing" this, but something needs to change.