### PR TITLE
vector::empty being used instead of vector::clear

### DIFF
--- a/src/tests/test_camera.cpp
+++ b/src/tests/test_camera.cpp
@@ -148,7 +148,7 @@ int main(int, char**)
             delete state.camera;
         }
     );
-    camera_states.empty();
+    camera_states.clear();
 
     // the camera will be deinitialized automatically in VideoCapture destructor
     return 0;


### PR DESCRIPTION
This doesn't affect anything, but thought I'd point out that empty() is being used where clear() is probably the intention.