### PR TITLE
added ignore_pose_from_one_tracker and extended check for GetIsPoseValid() in client dll

### DIFF
--- a/src/psmoveclient/ClientControllerView.cpp
+++ b/src/psmoveclient/ClientControllerView.cpp
@@ -932,7 +932,7 @@ bool ClientControllerView::GetIsPoseValid() const
     switch (ControllerViewType)
     {
     case eControllerType::PSMove:
-        return GetPSMoveView().GetIsOrientationValid() && GetPSMoveView().GetIsPositionValid();
+        return GetPSMoveView().GetIsOrientationValid() && GetPSMoveView().GetIsPositionValid() && GetPSMoveView().GetIsCurrentlyTracking();
     case eControllerType::PSNavi:
         // Never Tracking!
         return false;

--- a/src/psmoveservice/Device/Manager/TrackerManager.cpp
+++ b/src/psmoveservice/Device/Manager/TrackerManager.cpp
@@ -15,6 +15,7 @@ const int TrackerManagerConfig::CONFIG_VERSION = 2;
 TrackerManagerConfig::TrackerManagerConfig(const std::string &fnamebase)
     : PSMoveConfig(fnamebase)
 {
+	ignore_pose_from_one_tracker = false;
     optical_tracking_timeout= 100;
 	tracker_sleep_ms = 1;
 	use_bgr_to_hsv_lookup_table = true;
@@ -38,6 +39,7 @@ TrackerManagerConfig::config2ptree()
 
     pt.put("version", TrackerManagerConfig::CONFIG_VERSION);
 
+	pt.put("ignore_pose_from_one_tracker", ignore_pose_from_one_tracker);
     pt.put("optical_tracking_timeout", optical_tracking_timeout);
 	pt.put("use_bgr_to_hsv_lookup_table", use_bgr_to_hsv_lookup_table);
 	pt.put("tracker_sleep_ms", tracker_sleep_ms);
@@ -65,6 +67,7 @@ TrackerManagerConfig::ptree2config(const boost::property_tree::ptree &pt)
 
     if (version == TrackerManagerConfig::CONFIG_VERSION)
     {
+		ignore_pose_from_one_tracker = pt.get<bool>("ignore_pose_from_one_tracker", ignore_pose_from_one_tracker);
         optical_tracking_timeout= pt.get<int>("optical_tracking_timeout", optical_tracking_timeout);
 		use_bgr_to_hsv_lookup_table = pt.get<bool>("use_bgr_to_hsv_lookup_table", use_bgr_to_hsv_lookup_table);
 		tracker_sleep_ms = pt.get<int>("tracker_sleep_ms", tracker_sleep_ms);

--- a/src/psmoveservice/Device/Manager/TrackerManager.h
+++ b/src/psmoveservice/Device/Manager/TrackerManager.h
@@ -42,6 +42,7 @@ public:
     virtual const boost::property_tree::ptree config2ptree();
     virtual void ptree2config(const boost::property_tree::ptree &pt);
 
+	bool ignore_pose_from_one_tracker;
     long version;
     int optical_tracking_timeout;
 	int tracker_sleep_ms;

--- a/src/psmoveservice/Device/View/ServerControllerView.cpp
+++ b/src/psmoveservice/Device/View/ServerControllerView.cpp
@@ -496,7 +496,7 @@ void ServerControllerView::updateOpticalPoseEstimation(TrackerManager* tracker_m
 				assert(false && "unreachable");
 			}
         }
-        else if (projections_found == 1)
+        else if (projections_found == 1 && !DeviceManager::getInstance()->m_tracker_manager->getConfig().ignore_pose_from_one_tracker)
         {
 			const int tracker_id = valid_projection_tracker_ids[0];
 			const ServerTrackerViewPtr tracker = tracker_manager->getTrackerViewPtr(tracker_id);
@@ -2018,7 +2018,7 @@ static void computeSpherePoseForControllerFromMultipleTrackers(
 		}
 	}
 
-	if (pair_count == 0 && biggest_prjection_id >= 0)
+	if (pair_count == 0 && biggest_prjection_id >= 0 && !DeviceManager::getInstance()->m_tracker_manager->getConfig().ignore_pose_from_one_tracker)
 	{
 		// Position not triangulated from opposed camera, estimate from one tracker only.
 
@@ -2028,7 +2028,7 @@ static void computeSpherePoseForControllerFromMultipleTrackers(
 			&tracker_pose_estimations[biggest_prjection_id],
 			multicam_pose_estimation);		
 	}
-	else 
+	else if(pair_count > 0)
 	{
 		// Compute the average position
 		const float N = static_cast<float>(pair_count);
@@ -2039,6 +2039,7 @@ static void computeSpherePoseForControllerFromMultipleTrackers(
 
 		// Store the averaged tracking position
 		multicam_pose_estimation->position_cm = average_world_position;
+
 		multicam_pose_estimation->bCurrentlyTracking = true;
 	}
 


### PR DESCRIPTION
* added ignore_pose_from_one_tracker parameter to tell if service should calculate pose from one controller, useful in 3+ tracker setup
* GetIsPoseValid() in client dll is also checking if pose if valid for ps move