### PR TITLE
Added a semi-automatic colour calibration

### DIFF
--- a/src/psmoveconfigtool/AppStage_ColorCalibration.cpp
+++ b/src/psmoveconfigtool/AppStage_ColorCalibration.cpp
@@ -144,6 +144,9 @@ AppStage_ColorCalibration::AppStage_ColorCalibration(App *app)
     , m_trackerExposure(0)
     , m_trackerGain(0)
 	, m_bTurnOnAllControllers(false)
+	, m_bAutoChangeController(false)
+	, m_bAutoChangeColor(false)
+	, m_bAutoChangeTracker(false)
     , m_masterTrackingColorType(PSMoveTrackingColorType::Magenta)
 { 
     memset(m_colorPresets, 0, sizeof(m_colorPresets));
@@ -157,6 +160,9 @@ void AppStage_ColorCalibration::enter()
     assert(trackerInfo->tracker_id != -1);
 
     m_app->setCameraType(_cameraFixed);
+
+	tracker_count = trackerSettings->get_tracker_count();
+	tracker_index = trackerSettings->get_tracker_Index();
 
     // Use the tracker selected from the tracker settings menu
     assert(m_trackerView == nullptr);
@@ -196,6 +202,10 @@ void AppStage_ColorCalibration::enter()
 		m_lastMasterControllerSeqNum = -1;
 		m_bTurnOnAllControllers= false;
 		m_pendingControllerStartCount= false;
+
+		m_bAutoChangeController = (m_bAutoChangeController) ? m_bAutoChangeController : false;
+		m_bAutoChangeColor = (m_bAutoChangeColor) ? m_bAutoChangeColor : false;
+		m_bAutoChangeTracker = (m_bAutoChangeTracker) ? m_bAutoChangeTracker : false;
 	}
 
     // Request to start the tracker
@@ -359,6 +369,7 @@ void AppStage_ColorCalibration::renderUI()
         ImGuiWindowFlags_NoMove |
         ImGuiWindowFlags_NoScrollbar |
         ImGuiWindowFlags_NoCollapse;
+	int auto_calib_sleep = 150;
 
     switch (m_menuState)
     {
@@ -367,8 +378,13 @@ void AppStage_ColorCalibration::renderUI()
         // Video Control Panel
         {
             ImGui::SetNextWindowPos(ImVec2(10.f, 10.f));
-            ImGui::SetNextWindowSize(ImVec2(k_panel_width, 240));
+            ImGui::SetNextWindowSize(ImVec2(k_panel_width, 260));
             ImGui::Begin(k_window_title, nullptr, window_flags);
+
+			if (ImGui::Button("Return to Main Menu"))
+			{
+				request_exit_to_app_stage(AppStage_MainMenu::APP_STAGE_NAME);
+			}
             
             if (ImGui::Button("Return to Tracker Settings"))
             {
@@ -422,7 +438,7 @@ void AppStage_ColorCalibration::renderUI()
 					request_tracker_set_frame_rate(m_trackerFramerate + frame_rate_positive_change);
 				}
 				ImGui::SameLine();
-				ImGui::Text("Framerate: %f", m_trackerFramerate);
+				ImGui::Text("Framerate: %.0f", m_trackerFramerate);
 
                 if (ImGui::Button("-##Exposure"))
                 {
@@ -434,7 +450,7 @@ void AppStage_ColorCalibration::renderUI()
                     request_tracker_set_exposure(m_trackerExposure + 8);
                 }
                 ImGui::SameLine();
-                ImGui::Text("Exposure: %f", m_trackerExposure);
+                ImGui::Text("Exposure: %.0f", m_trackerExposure);
 
                 if (ImGui::Button("-##Gain"))
                 {
@@ -446,7 +462,7 @@ void AppStage_ColorCalibration::renderUI()
                     request_tracker_set_gain(m_trackerGain + 8);
                 }
                 ImGui::SameLine();
-                ImGui::Text("Gain: %f", m_trackerGain);
+                ImGui::Text("Gain: %.0f", m_trackerGain);
 
                 // Render all of the option sets fetched from the settings query
                 for (auto it = m_trackerOptions.begin(); it != m_trackerOptions.end(); ++it)
@@ -493,23 +509,36 @@ void AppStage_ColorCalibration::renderUI()
         
         if (ImGui::IsMouseClicked(1) )
         {
-            ImVec2 mousePos = ImGui::GetMousePos();
-            ImVec2 dispSize = ImGui::GetIO().DisplaySize;
-            int img_x = mousePos.x * m_video_buffer_state->hsvBuffer->cols / static_cast<int>(dispSize.x);
-            int img_y = mousePos.y * m_video_buffer_state->hsvBuffer->rows / static_cast<int>(dispSize.y);
-            cv::Vec< unsigned char, 3 > hsv_pixel = m_video_buffer_state->hsvBuffer->at<cv::Vec< unsigned char, 3 >>(cv::Point(img_x, img_y));
-            
-            TrackerColorPreset preset = getColorPreset();
-            preset.hue_center = hsv_pixel[0];
-            preset.saturation_center = hsv_pixel[1];
-            preset.value_center = hsv_pixel[2];
-            request_tracker_set_color_preset(m_masterTrackingColorType, preset);
-        }
+			ImVec2 mousePos = ImGui::GetMousePos();
+			ImVec2 dispSize = ImGui::GetIO().DisplaySize;
+			int img_x = mousePos.x * m_video_buffer_state->hsvBuffer->cols / static_cast<int>(dispSize.x);
+			int img_y = mousePos.y * m_video_buffer_state->hsvBuffer->rows / static_cast<int>(dispSize.y);
+			cv::Vec< unsigned char, 3 > hsv_pixel = m_video_buffer_state->hsvBuffer->at<cv::Vec< unsigned char, 3 >>(cv::Point(img_x, img_y));
+
+			TrackerColorPreset preset = getColorPreset();
+			preset.hue_center = hsv_pixel[0];
+			preset.saturation_center = hsv_pixel[1];
+			preset.value_center = hsv_pixel[2];
+			request_tracker_set_color_preset(m_masterTrackingColorType, preset);
+
+			if (m_bAutoChangeColor) {
+				setState(eMenuState::blank1);
+				request_set_controller_tracking_color(m_masterControllerView, PSMoveTrackingColorType::Magenta);
+				m_masterTrackingColorType = PSMoveTrackingColorType::Magenta;
+				Sleep(auto_calib_sleep);
+			}
+			else if (m_bAutoChangeController) {
+				setState(eMenuState::changeController);
+			}
+			else if (m_bAutoChangeTracker) {
+				setState(eMenuState::changeTracker);
+			}
+		}
 
         // Color Control Panel
         {
             ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - k_panel_width - 10, 20.f));
-            ImGui::SetNextWindowSize(ImVec2(k_panel_width, 200));
+            ImGui::SetNextWindowSize(ImVec2(k_panel_width, 280));
             ImGui::Begin("Controller Color", nullptr, window_flags);
 
 			if (m_masterControllerView != nullptr)
@@ -635,11 +664,98 @@ void AppStage_ColorCalibration::renderUI()
             ImGui::SameLine();
             ImGui::Text("Value Range: %f", getColorPreset().value_range);
 
+			// -- Auto Calibration --
+			ImGui::Text("Auto Change Setings:");
+			ImGui::Checkbox("Color", &m_bAutoChangeColor);
+			ImGui::SameLine();
+			ImGui::Checkbox("Controller", &m_bAutoChangeController);
+			ImGui::SameLine();
+			ImGui::Checkbox("Tracker", &m_bAutoChangeTracker);
 
+			// -- Change Controller --
+			if (ImGui::Button("<##Controller"))
+			{
+				request_change_controller(-1);
+			}
+			ImGui::SameLine();
+			if (ImGui::Button(">##Controller"))
+			{
+				request_change_controller(1);
+			}
+			ImGui::SameLine();
+			ImGui::Text("Controller ID: %d", m_overrideControllerId);
+
+			// -- Change Tracker --
+			if (ImGui::Button("<##Tracker"))
+			{
+				request_change_tracker(-1);
+			}
+			ImGui::SameLine();
+			if (ImGui::Button(">##Tracker"))
+			{
+				request_change_tracker(1);
+			}
+			ImGui::SameLine();
+			ImGui::Text("Tracker ID: %d", tracker_index);
+			
             ImGui::End();
         }
     } break;
 
+    case eMenuState::autoConfig:
+	{
+		PSMoveTrackingColorType new_color =
+			static_cast<PSMoveTrackingColorType>(
+			(m_masterTrackingColorType + 1) % PSMoveTrackingColorType::MAX_PSMOVE_COLOR_TYPES);
+
+		ImVec2 mousePos = ImGui::GetMousePos();
+		ImVec2 dispSize = ImGui::GetIO().DisplaySize;
+		int img_x = mousePos.x * m_video_buffer_state->hsvBuffer->cols / static_cast<int>(dispSize.x);
+		int img_y = mousePos.y * m_video_buffer_state->hsvBuffer->rows / static_cast<int>(dispSize.y);
+		cv::Vec< unsigned char, 3 > hsv_pixel = m_video_buffer_state->hsvBuffer->at<cv::Vec< unsigned char, 3 >>(cv::Point(img_x, img_y));
+
+		TrackerColorPreset preset = getColorPreset();
+		preset.hue_center = hsv_pixel[0];
+		preset.saturation_center = hsv_pixel[1];
+		preset.value_center = hsv_pixel[2];
+		request_tracker_set_color_preset(m_masterTrackingColorType, preset);
+
+		request_set_controller_tracking_color(m_masterControllerView, new_color);
+
+		if (new_color == PSMoveTrackingColorType::Magenta) {
+			if (m_bAutoChangeController) setState(eMenuState::changeController);
+			else if (m_bAutoChangeTracker) setState(eMenuState::changeTracker);
+			else setState(eMenuState::manualConfig);
+		}
+		else setState(eMenuState::blank1);
+
+		m_masterTrackingColorType = new_color;
+
+		Sleep(auto_calib_sleep);
+	} break;
+
+	case eMenuState::blank1:
+		setState(eMenuState::blank3);
+		Sleep(auto_calib_sleep);
+		break;
+	case eMenuState::blank2:
+		setState(eMenuState::blank2);
+		Sleep(auto_calib_sleep);
+		break;
+	case eMenuState::blank3:
+		setState(eMenuState::autoConfig);
+		Sleep(auto_calib_sleep);
+		break;
+	case eMenuState::changeController:
+	{
+		setState(eMenuState::manualConfig);
+		request_change_controller(1);
+	}
+		break;
+	case eMenuState::changeTracker:
+		setState(eMenuState::manualConfig);
+		request_change_tracker(1);
+		break;
     case eMenuState::pendingTrackerStartStreamRequest:
     case eMenuState::pendingControllerStartRequest:
 	case eMenuState::pendingHmdStartRequest:
@@ -1293,5 +1409,62 @@ void AppStage_ColorCalibration::request_turn_on_all_tracking_bulbs(bool bEnabled
 		{
 			controllerView->SetLEDOverride(0, 0, 0);
 		}
+	}
+}
+
+void AppStage_ColorCalibration::request_change_controller(int step)
+{
+	assert(m_controllerViews.size() == m_controllerTrackingColorTypes.size());
+	//for (int list_index = 0; list_index < m_controllerViews.size(); ++list_index)
+	{
+		ClientControllerView *controllerView = m_controllerViews[m_overrideControllerId];
+
+		if (controllerView == m_masterControllerView) {
+			m_masterControllerView->SetLEDOverride(0, 0, 0);
+			if (m_overrideControllerId + step < m_controllerViews.size() && m_overrideControllerId + step >= 0) {
+				m_overrideControllerId = m_overrideControllerId + step;
+				m_masterControllerView = m_controllerViews[m_overrideControllerId];
+				request_set_controller_tracking_color(m_masterControllerView, m_masterTrackingColorType);
+				//setState(eMenuState::manualConfig);
+			}
+			else if (step > 0) {
+				m_overrideControllerId = 0;
+				m_masterControllerView = m_controllerViews[0];
+				request_set_controller_tracking_color(m_masterControllerView, m_masterTrackingColorType);
+				if (m_bAutoChangeTracker) setState(eMenuState::changeTracker);
+				//else setState(eMenuState::manualConfig);
+			}
+			else {
+				m_overrideControllerId = m_controllerViews.size() -1;
+				m_masterControllerView = m_controllerViews[m_overrideControllerId];
+				request_set_controller_tracking_color(m_masterControllerView, m_masterTrackingColorType);
+				//if (m_bAutoChangeTracker) setState(eMenuState::changeTracker);
+				//else 
+				//	setState(eMenuState::manualConfig);
+			}
+			//break;
+		}
+	}
+}
+
+void AppStage_ColorCalibration::request_change_tracker(int step)
+{
+	m_app->getAppStage<AppStage_ColorCalibration>()->
+	set_autoConfig(m_bAutoChangeColor, m_bAutoChangeController, m_bAutoChangeTracker);
+	//int TrackerId = m_trackerView->getTrackerId();
+	if (tracker_index + step < tracker_count && tracker_index + step >= 0)
+	{
+		m_app->getAppStage<AppStage_TrackerSettings>()->set_selectedTrackerIndex(tracker_index + step);
+		request_exit_to_app_stage(AppStage_ColorCalibration::APP_STAGE_NAME);
+	}
+	else if (step > 0)
+	{
+		m_app->getAppStage<AppStage_TrackerSettings>()->set_selectedTrackerIndex(0);
+		request_exit_to_app_stage(AppStage_ColorCalibration::APP_STAGE_NAME);
+	}
+	else
+	{
+		m_app->getAppStage<AppStage_TrackerSettings>()->set_selectedTrackerIndex(tracker_count -1);
+		request_exit_to_app_stage(AppStage_ColorCalibration::APP_STAGE_NAME);
 	}
 }

--- a/src/psmoveconfigtool/AppStage_ColorCalibration.h
+++ b/src/psmoveconfigtool/AppStage_ColorCalibration.h
@@ -32,6 +32,12 @@ public:
 	inline void set_override_tracking_color(PSMoveTrackingColorType tracking_color) {
 		m_masterTrackingColorType = tracking_color;
 	}
+	
+	inline void set_autoConfig(bool colour, bool controller, bool tracker) {
+		m_bAutoChangeColor = colour;
+		m_bAutoChangeController = controller;
+		m_bAutoChangeTracker = tracker;
+	}
 
 protected:
     enum eMenuState
@@ -39,6 +45,12 @@ protected:
         inactive,
         waitingForStreamStartResponse,
         manualConfig,
+		autoConfig,
+		blank1,
+		blank2,
+		blank3,
+		changeController,
+		changeTracker,
 
         pendingControllerStartRequest,
         failedControllerStartRequest,
@@ -136,6 +148,9 @@ protected:
 
 	void request_turn_on_all_tracking_bulbs(bool bEnabled);
 
+	void request_change_controller(int step);
+	void request_change_tracker(int step);
+
     inline TrackerColorPreset getColorPreset()
     { return m_colorPresets[m_masterTrackingColorType]; }
 
@@ -166,10 +181,17 @@ private:
     double m_trackerGain;
     std::vector<TrackerOption> m_trackerOptions;
     TrackerColorPreset m_colorPresets[PSMoveTrackingColorType::MAX_PSMOVE_COLOR_TYPES];
+	int tracker_count;
+	int tracker_index;
 
     // Color Settings
 	bool m_bTurnOnAllControllers;
     PSMoveTrackingColorType m_masterTrackingColorType;
+
+	// Auto Calibration options
+	bool m_bAutoChangeController;
+	bool m_bAutoChangeColor;
+	bool m_bAutoChangeTracker;
 };
 
 #endif // APP_STAGE_COLOR_CALIBRATION_H

--- a/src/psmoveconfigtool/AppStage_TrackerSettings.cpp
+++ b/src/psmoveconfigtool/AppStage_TrackerSettings.cpp
@@ -150,17 +150,29 @@ void AppStage_TrackerSettings::renderUI()
                 {
                     --m_selectedTrackerIndex;
                 }
-                ImGui::SameLine();
             }
+			else {
+				if (ImGui::Button("<##TrackerIndex"))
+				{
+					m_selectedTrackerIndex = static_cast<int>(m_trackerInfos.size()) -1;
+				}
+			}
+			ImGui::SameLine();
             ImGui::Text("Tracker: %d", m_selectedTrackerIndex);
+			ImGui::SameLine();
             if (m_selectedTrackerIndex + 1 < static_cast<int>(m_trackerInfos.size()))
             {
-                ImGui::SameLine();
                 if (ImGui::Button(">##TrackerIndex"))
                 {
                     ++m_selectedTrackerIndex;
                 }
-            }
+			}
+			else {
+				if (ImGui::Button(">##TrackerIndex"))
+				{
+					m_selectedTrackerIndex = 0;
+				}
+			}
 
             ImGui::BulletText("Tracker ID: %d", trackerInfo.tracker_id);
 

--- a/src/psmoveconfigtool/AppStage_TrackerSettings.h
+++ b/src/psmoveconfigtool/AppStage_TrackerSettings.h
@@ -32,6 +32,16 @@ public:
             ? &m_trackerInfos[m_selectedTrackerIndex]
             : nullptr;
     }
+	
+	inline void set_selectedTrackerIndex(int index) {
+		m_selectedTrackerIndex = 
+			(index != -1 && index < m_trackerInfos.size())
+			? index
+			: m_selectedTrackerIndex;
+	}
+
+	inline int get_tracker_count() const { return m_trackerInfos.size(); }
+	inline int get_tracker_Index() const { return m_selectedTrackerIndex; }
 
 	inline int get_controller_count() const { return m_controllerInfos.size(); }	
 	inline const ControllerInfo * get_controller_info(int index) const { return &m_controllerInfos[index]; }


### PR DESCRIPTION
There are now automation options for changing the colour, controller and
tracker after setting the colour preset with a right-click. The automation
is prioritised as colour then controller then tracker. When cycling
through the colours the presets are automatically saved (the controller
and mouse must remain overlapped to be succesful).

Buttons have also been added to the colour configuration window to be able
to manually cycle through the controllers and trackers with out leaving
the window. A main menu button has also been added. The trailing zeros of
the frame rate, exposure and gain have been removed.

The buttons for changing the tracker in the tracker setting window are now
looped such that the first and last trackers can be switch to from one
another with a single click.

I think this will help speed up calibration especially for when lighting conditions change.