### PR TITLE
Shrink cross hairs instead of removing them completely

### DIFF
--- a/src/psmoveclient/ClientPSMoveAPI.cpp
+++ b/src/psmoveclient/ClientPSMoveAPI.cpp
@@ -391,19 +391,13 @@ public:
         return request->request_id();
     }
 
-    ClientPSMoveAPI::t_request_id start_tracker_data_stream(ClientTrackerView *view, unsigned int flags)
+    ClientPSMoveAPI::t_request_id start_tracker_data_stream(ClientTrackerView *view)
     {
         CLIENT_LOG_INFO("start_tracker_data_stream") << "requesting tracker stream start for TrackerID: " << view->getTrackerId() << std::endl;
 
         // Tell the psmove service that we are acquiring this tracker
         RequestPtr request(new PSMoveProtocol::Request());
         request->set_type(PSMoveProtocol::Request_RequestType_START_TRACKER_DATA_STREAM);
-
-        if ((flags & ClientPSMoveAPI::includeDebugRendering) > 0)
-        {
-            request->mutable_request_start_tracker_data_stream()->set_include_debug_rendering(true);
-        }
-
         request->mutable_request_start_tracker_data_stream()->set_tracker_id(view->getTrackerId());
 
         m_request_manager.send_request(request);
@@ -1067,13 +1061,13 @@ ClientPSMoveAPI::get_tracker_list()
 }
 
 ClientPSMoveAPI::t_request_id 
-ClientPSMoveAPI::start_tracker_data_stream(ClientTrackerView *view, unsigned int tracker_stream_options)
+ClientPSMoveAPI::start_tracker_data_stream(ClientTrackerView *view)
 {
     ClientPSMoveAPI::t_request_id request_id = ClientPSMoveAPI::INVALID_REQUEST_ID;
 
     if (ClientPSMoveAPI::m_implementation_ptr != nullptr)
     {
-        request_id = ClientPSMoveAPI::m_implementation_ptr->start_tracker_data_stream(view, tracker_stream_options);
+        request_id = ClientPSMoveAPI::m_implementation_ptr->start_tracker_data_stream(view);
     }
 
     return request_id;

--- a/src/psmoveclient/ClientPSMoveAPI.h
+++ b/src/psmoveclient/ClientPSMoveAPI.h
@@ -47,12 +47,6 @@ public:
 		disableROI = 0x20,
     };    
 
-    enum eTrackerDataStreamFlags
-    {
-        defaultTrackerOptions = 0x00,
-        includeDebugRendering = 0x01,
-    };  
-
     enum eControllerRumbleChannel
     {
         channelAll,
@@ -221,7 +215,7 @@ public:
 
 	static t_request_id get_tracking_space_settings();
 	static t_request_id get_tracker_list();
-    static t_request_id start_tracker_data_stream(ClientTrackerView *view, unsigned int data_stream_flags);
+    static t_request_id start_tracker_data_stream(ClientTrackerView *view);
     static t_request_id stop_tracker_data_stream(ClientTrackerView *view);
     
     /// HMD Methods

--- a/src/psmoveclient/PSMoveClient_CAPI.cpp
+++ b/src/psmoveclient/PSMoveClient_CAPI.cpp
@@ -716,7 +716,7 @@ PSMResult PSM_GetTrackerList(PSMTrackerList *out_tracker_list, int timeout_ms)
     return result;
 }
 
-PSMResult PSM_StartTrackerDataStream(PSMTrackerID tracker_id, unsigned int data_stream_flags, int timeout_ms)
+PSMResult PSM_StartTrackerDataStream(PSMTrackerID tracker_id, int timeout_ms)
 {
     PSMResult result= PSMResult_Error;
 
@@ -724,7 +724,7 @@ PSMResult PSM_StartTrackerDataStream(PSMTrackerID tracker_id, unsigned int data_
     {
         ClientTrackerView *view = g_tracker_views[tracker_id];
 
-        result= blockUntilResponse(ClientPSMoveAPI::start_tracker_data_stream(view, data_stream_flags), timeout_ms);
+        result= blockUntilResponse(ClientPSMoveAPI::start_tracker_data_stream(view), timeout_ms);
     }
 
     return result;
@@ -797,7 +797,7 @@ PSMResult PSM_GetTrackerListAsync(PSMRequestID *out_request_id)
     return result;
 }
 
-PSMResult PSM_StartTrackerDataStreamAsync(PSMTrackerID tracker_id, unsigned int data_stream_flags, PSMRequestID *out_request_id)
+PSMResult PSM_StartTrackerDataStreamAsync(PSMTrackerID tracker_id, PSMRequestID *out_request_id)
 {
     PSMResult result= PSMResult_Error;
 
@@ -807,7 +807,7 @@ PSMResult PSM_StartTrackerDataStreamAsync(PSMTrackerID tracker_id, unsigned int 
 
         if (view != nullptr)
         {
-            ClientPSMoveAPI::t_request_id req_id = ClientPSMoveAPI::start_tracker_data_stream(view, data_stream_flags);
+            ClientPSMoveAPI::t_request_id req_id = ClientPSMoveAPI::start_tracker_data_stream(view);
 
             if (out_request_id != nullptr)
             {

--- a/src/psmoveclient/PSMoveClient_CAPI.h
+++ b/src/psmoveclient/PSMoveClient_CAPI.h
@@ -73,12 +73,6 @@ typedef enum _PSMControllerType
 	PSMController_DualShock4
 } PSMControllerType;
 
-typedef enum _PSMTrackerDataStreamFlags
-{
-    PSMTrackerFlags_defaultStreamOptions = 0x00,
-    PSMTrackerFlags_includeDebugRendering = 0x01,
-} PSMTrackerDataStreamFlags;
-
 typedef enum _PSMTrackerType
 {
     PSMTracker_None= -1,
@@ -555,13 +549,13 @@ PSM_PUBLIC_FUNCTION(PSMResult) PSM_FreeTrackerListener(PSMTrackerID controller_i
 
 /// Blocking Tracker Methods
 PSM_PUBLIC_FUNCTION(PSMResult) PSM_GetTrackerList(PSMTrackerList *out_tracker_list, int timeout_ms);
-PSM_PUBLIC_FUNCTION(PSMResult) PSM_StartTrackerDataStream(PSMTrackerID tracker_id, unsigned int data_stream_flags, int timeout_ms);
+PSM_PUBLIC_FUNCTION(PSMResult) PSM_StartTrackerDataStream(PSMTrackerID tracker_id, int timeout_ms);
 PSM_PUBLIC_FUNCTION(PSMResult) PSM_StopTrackerDataStream(PSMTrackerID tracker_id, int timeout_ms);
 PSM_PUBLIC_FUNCTION(PSMResult) PSM_GetHMDTrackingSpaceSettings(PSMTrackingSpace *out_tracking_space, int timeout_ms);
 
 /// Async Tracker Methods
 PSM_PUBLIC_FUNCTION(PSMResult) PSM_GetTrackerListAsync(PSMRequestID *out_request_id);
-PSM_PUBLIC_FUNCTION(PSMResult) PSM_StartTrackerDataStreamAsync(PSMTrackerID tracker_id, unsigned int data_stream_flags, PSMRequestID *out_request_id);
+PSM_PUBLIC_FUNCTION(PSMResult) PSM_StartTrackerDataStreamAsync(PSMTrackerID tracker_id, PSMRequestID *out_request_id);
 PSM_PUBLIC_FUNCTION(PSMResult) PSM_StopTrackerDataStreamAsync(PSMTrackerID tracker_id, PSMRequestID *out_request_id);
 PSM_PUBLIC_FUNCTION(PSMResult) PSM_GetHMDTrackingSpaceSettingsAsync(PSMRequestID *out_request_id);
 

--- a/src/psmoveconfigtool/AppStage_ColorCalibration.cpp
+++ b/src/psmoveconfigtool/AppStage_ColorCalibration.cpp
@@ -941,7 +941,7 @@ void AppStage_ColorCalibration::request_tracker_start_stream()
 
         // Tell the psmove service that we want to start streaming data from the tracker
         ClientPSMoveAPI::register_callback(
-            ClientPSMoveAPI::start_tracker_data_stream(m_trackerView, ClientPSMoveAPI::defaultTrackerOptions),
+            ClientPSMoveAPI::start_tracker_data_stream(m_trackerView),
             AppStage_ColorCalibration::handle_tracker_start_stream_response, this);
     }
 }

--- a/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.cpp
+++ b/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.cpp
@@ -333,7 +333,7 @@ void AppStage_ComputeTrackerPoses::renderUI()
         } break;
 
     case eMenuState::verifyTrackers:
-        {
+		{
             ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 2.f - 500.f / 2.f, 20.f));
             ImGui::SetNextWindowSize(ImVec2(500.f, (m_trackerViews.size() > 0) ? 150.f : 100.f));
             ImGui::Begin(k_window_title, nullptr, window_flags);
@@ -343,7 +343,7 @@ void AppStage_ComputeTrackerPoses::renderUI()
 
             if (m_trackerViews.size() > 1)
             {
-                ImGui::Text("Tracker #%d", m_renderTrackerIndex + 1);
+                ImGui::Text("Tracker #%d", m_renderTrackerIndex);
 
                 if (ImGui::Button("Previous Tracker"))
                 {
@@ -375,7 +375,8 @@ void AppStage_ComputeTrackerPoses::renderUI()
             }
 
             ImGui::End();
-        } break;
+        }
+		break;
 
 	case eMenuState::selectCalibrationMethod:
 		{
@@ -479,7 +480,25 @@ void AppStage_ComputeTrackerPoses::renderUI()
 			ImGui::SetNextWindowSize(ImVec2(200, 100));
 			ImGui::Begin("Tracker Video Feed", nullptr, window_flags);
 
-			ImGui::Text("Tracker ID: #%d", m_renderTrackerIter->second.trackerView->getTrackerId());
+			//ImGui::Text("Tracker ID: #%d", m_renderTrackerIter->second.trackerView->getTrackerId());
+
+			if (m_trackerViews.size() > 1)
+			{
+				if (ImGui::Button("<##Previous Tracker"))
+				{
+					go_previous_tracker();
+				}
+				ImGui::SameLine();
+				ImGui::Text("Tracker ID: #%d", m_renderTrackerIter->second.trackerView->getTrackerId());
+				ImGui::SameLine();
+				if (ImGui::Button(">##Next Tracker"))
+				{
+					go_next_tracker();
+				}
+			} 
+			else {
+				ImGui::Text("Tracker ID: 0");
+			}
 
 			if (ImGui::Button("Return"))
 			{
@@ -987,7 +1006,7 @@ void AppStage_ComputeTrackerPoses::request_tracker_start_stream(
 
     // Request data to start streaming to the tracker
     ClientPSMoveAPI::register_callback(
-        ClientPSMoveAPI::start_tracker_data_stream(trackerState.trackerView),
+		ClientPSMoveAPI::start_tracker_data_stream(trackerState.trackerView),
         AppStage_ComputeTrackerPoses::handle_tracker_start_stream_response, this);
 }
 

--- a/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.cpp
+++ b/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.cpp
@@ -987,9 +987,7 @@ void AppStage_ComputeTrackerPoses::request_tracker_start_stream(
 
     // Request data to start streaming to the tracker
     ClientPSMoveAPI::register_callback(
-        ClientPSMoveAPI::start_tracker_data_stream(
-			trackerState.trackerView, 
-			m_bSkipCalibration ? ClientPSMoveAPI::includeDebugRendering : ClientPSMoveAPI::defaultTrackerOptions),
+        ClientPSMoveAPI::start_tracker_data_stream(trackerState.trackerView),
         AppStage_ComputeTrackerPoses::handle_tracker_start_stream_response, this);
 }
 

--- a/src/psmoveconfigtool/AppStage_DistortionCalibration.cpp
+++ b/src/psmoveconfigtool/AppStage_DistortionCalibration.cpp
@@ -846,7 +846,7 @@ void AppStage_DistortionCalibration::request_tracker_start_stream()
 
         // Tell the psmove service that we want to start streaming data from the tracker
         ClientPSMoveAPI::register_callback(
-            ClientPSMoveAPI::start_tracker_data_stream(m_tracker_view, ClientPSMoveAPI::defaultTrackerOptions),
+            ClientPSMoveAPI::start_tracker_data_stream(m_tracker_view),
             AppStage_DistortionCalibration::handle_tracker_start_stream_response, this);
     }
 }

--- a/src/psmoveconfigtool/AppStage_HMDModelCalibration.cpp
+++ b/src/psmoveconfigtool/AppStage_HMDModelCalibration.cpp
@@ -1180,7 +1180,7 @@ void AppStage_HMDModelCalibration::request_tracker_start_stream(
 
 	// Request data to start streaming to the tracker
 	ClientPSMoveAPI::register_callback(
-		ClientPSMoveAPI::start_tracker_data_stream(tracker_view, ClientPSMoveAPI::includeDebugRendering),
+		ClientPSMoveAPI::start_tracker_data_stream(tracker_view),
 		AppStage_HMDModelCalibration::handle_tracker_start_stream_response, this);
 }
 

--- a/src/psmoveconfigtool/AppStage_TestTracker.cpp
+++ b/src/psmoveconfigtool/AppStage_TestTracker.cpp
@@ -204,7 +204,7 @@ void AppStage_TestTracker::request_tracker_start_stream()
 
         // Tell the psmove service that we want to start streaming data from the tracker
         ClientPSMoveAPI::register_callback(
-            ClientPSMoveAPI::start_tracker_data_stream(m_tracker_view, ClientPSMoveAPI::includeDebugRendering),
+            ClientPSMoveAPI::start_tracker_data_stream(m_tracker_view),
             AppStage_TestTracker::handle_tracker_start_stream_response, this);
     }
 }

--- a/src/psmoveprotocol/PSMoveProtocol.proto
+++ b/src/psmoveprotocol/PSMoveProtocol.proto
@@ -287,7 +287,6 @@ message Request {
     // NOTE: DeviceDataFrame packets will start streaming to client upon receiving this request
     message RequestStartTrackerDataStream {
         int32 tracker_id = 1;
-        bool include_debug_rendering = 2;
     }
     RequestStartTrackerDataStream request_start_tracker_data_stream = 21;
 

--- a/src/psmoveprotocol/ProtocolVersion.h
+++ b/src/psmoveprotocol/ProtocolVersion.h
@@ -13,7 +13,7 @@
 #define PSM_PHASE           alpha
 #define PSM_MINOR_VERSION   7
 #define PSM_PATCH_VERSION   0
-#define PSM_BUILD_NUMBER    10
+#define PSM_BUILD_NUMBER    9
 
 /// "Product.Major-Phase Minor.Patch"
 #if !defined(PSM_VERSION_STRING)

--- a/src/psmoveservice/Device/View/ServerTrackerView.cpp
+++ b/src/psmoveservice/Device/View/ServerTrackerView.cpp
@@ -613,7 +613,9 @@ public:
 		const cv::Point2f massCenter = computeSafeCenterOfMassForContour<t_opencv_int_contour>(contour);
         cv::drawContours(*bgrShmemBuffer, contours, 0, cv::Scalar(255, 255, 255));
         cv::rectangle(*bgrShmemBuffer, cv::boundingRect(contour), cv::Scalar(255, 255, 255));
-        cv::drawMarker(*bgrShmemBuffer, massCenter, cv::Scalar(255, 255, 255));
+		cv::drawMarker(*bgrShmemBuffer, massCenter, cv::Scalar(255, 255, 255), 0,
+			(cv::boundingRect(contour).height < cv::boundingRect(contour).width) ?
+			cv::boundingRect(contour).height : cv::boundingRect(contour).width);
     }
     
     void
@@ -641,7 +643,8 @@ public:
 					ell_size,
 					pose_projection.shape.ellipse.angle,
 					0, 360, cv::Scalar(0, 0, 255));
-				cv::drawMarker(*bgrShmemBuffer, ell_center, cv::Scalar(0, 0, 255));
+				cv::drawMarker(*bgrShmemBuffer, ell_center, cv::Scalar(0, 0, 255), 0,
+					(ell_size.height < ell_size.width) ? ell_size.height * 2 : ell_size.width * 2);
 			} break;
 		case eCommonTrackingProjectionType::ProjectionType_LightBar:
 			{

--- a/src/psmoveservice/Device/View/ServerTrackerView.cpp
+++ b/src/psmoveservice/Device/View/ServerTrackerView.cpp
@@ -363,7 +363,7 @@ public:
         }
         
         //Apply default ROI (full frame).
-        applyROI(cv::Rect2i(cv::Point(0,0), cv::Size(frameWidth, frameHeight)), false);
+        applyROI(cv::Rect2i(cv::Point(0,0), cv::Size(frameWidth, frameHeight)));
     }
 
     virtual ~OpenCVBufferState()
@@ -425,7 +425,7 @@ public:
         }
     }
     
-    void applyROI(cv::Rect2i ROI, bool bShowDebugRender)
+    void applyROI(cv::Rect2i ROI)
     {
 		// Make sure the ROI box is always clamped in bounds of the frame buffer
 		int x0= std::min(std::max(ROI.tl().x, 0), frameWidth-1);
@@ -463,10 +463,7 @@ public:
         updateHsvBuffer();
         
         //Draw ROI.
-		if (bShowDebugRender)
-		{
-			cv::rectangle(*bgrShmemBuffer, ROI, cv::Scalar(255, 0, 0));
-		}
+        cv::rectangle(*bgrShmemBuffer, ROI, cv::Scalar(255, 0, 0));
     }
 
     // Return points in raw image space:
@@ -870,25 +867,15 @@ void ServerTrackerView::close()
     ServerDeviceView::close();
 }
 
-void ServerTrackerView::startSharedMemoryVideoStream(bool include_debug_rendering)
+void ServerTrackerView::startSharedMemoryVideoStream()
 {
     ++m_shared_memory_video_stream_count;
-	
-	if (include_debug_rendering)
-	{
-		++m_include_debug_rendering_count;
-	}
 }
 
 void ServerTrackerView::stopSharedMemoryVideoStream()
 {
     assert(m_shared_memory_video_stream_count > 0);
     --m_shared_memory_video_stream_count;
-
-	if (m_include_debug_rendering_count > 0)
-	{
-		--m_include_debug_rendering_count;
-	}
 }
 
 bool ServerTrackerView::poll()
@@ -1154,7 +1141,6 @@ ServerTrackerView::computeProjectionForController(
 	const CommonDeviceTrackingShape *tracking_shape,
     ControllerOpticalPoseEstimation *out_pose_estimate)
 {
-	const bool bShowDebugRendering= getIsDebugRenderingEnabled();
     bool bSuccess = true;
 
     // Get the HSV filter used to find the tracking blob
@@ -1188,7 +1174,7 @@ ServerTrackerView::computeProjectionForController(
 		bIsTracking ? &priorPoseEst->projection : nullptr,
 		tracking_shape);
 
-    m_opencv_buffer_state->applyROI(ROI, bShowDebugRendering);
+    m_opencv_buffer_state->applyROI(ROI);
 
     // Find the contour associated with the controller
 	t_opencv_int_contour_list biggest_contours;
@@ -1216,11 +1202,7 @@ ServerTrackerView::computeProjectionForController(
 				// Compute the convex hull of the contour
 				t_opencv_int_contour convex_contour;
 				cv::convexHull(biggest_contours[0], convex_contour);
-
-				if (bShowDebugRendering)
-				{
-					m_opencv_buffer_state->draw_contour(convex_contour);
-				}
+				m_opencv_buffer_state->draw_contour(convex_contour);
 
 				// Convert integer to float
 				t_opencv_float_contour convex_contour_f;
@@ -1279,10 +1261,7 @@ ServerTrackerView::computeProjectionForController(
 					k_real_pi*out_pose_estimate->projection.shape.ellipse.half_x_extent*out_pose_estimate->projection.shape.ellipse.half_y_extent;
                 
                 //Draw results onto m_opencv_buffer_state
-				if (bShowDebugRendering)
-				{
-					m_opencv_buffer_state->draw_pose_projection(out_pose_estimate->projection);
-				}
+                m_opencv_buffer_state->draw_pose_projection(out_pose_estimate->projection);
 
                 bSuccess = true;
             } break;
@@ -1291,10 +1270,7 @@ ServerTrackerView::computeProjectionForController(
         case eCommonTrackingShapeType::LightBar:
             {
 				// Draw the raw source contour
-				if (bShowDebugRendering)
-				{
-					m_opencv_buffer_state->draw_contour(biggest_contours[0]);
-				}
+				m_opencv_buffer_state->draw_contour(biggest_contours[0]);
 
 				// Convert integer contour to float
 				t_opencv_float_contour biggest_contour_f;
@@ -1316,10 +1292,7 @@ ServerTrackerView::computeProjectionForController(
                         &out_pose_estimate->projection);
 
 				//Draw results onto m_opencv_buffer_state
-				if (bShowDebugRendering)
-				{
-					m_opencv_buffer_state->draw_pose_projection(out_pose_estimate->projection);
-				}
+				m_opencv_buffer_state->draw_pose_projection(out_pose_estimate->projection);
             } break;
         default:
             assert(0 && "Unreachable");
@@ -1381,7 +1354,6 @@ bool ServerTrackerView::computePoseForHMD(
 	const CommonDevicePose *tracker_pose_guess,
 	struct HMDOpticalPoseEstimation *out_pose_estimate)
 {
-	const bool bShowDebugRendering= getIsDebugRenderingEnabled();
 	bool bSuccess = true;
 
 	// Get the tracking shape used by the controller
@@ -1416,7 +1388,7 @@ bool ServerTrackerView::computePoseForHMD(
 		bIsTracking ? tracked_hmd->getPoseFilter() : nullptr,
 		bIsTracking ? &tracked_hmd->getTrackerPoseEstimate(this->getDeviceID())->projection : nullptr,
 		&tracking_shape);
-	m_opencv_buffer_state->applyROI(ROI, bShowDebugRendering);
+	m_opencv_buffer_state->applyROI(ROI);
 
 	// Find the N best contours associated with the HMD
 	t_opencv_int_contour_list biggest_contours;
@@ -1440,10 +1412,7 @@ bool ServerTrackerView::computePoseForHMD(
 		for (auto it = biggest_contours.begin(); it != biggest_contours.end(); ++it)
 		{
 			// Draw the source contour
-			if (bShowDebugRendering)
-			{
-				m_opencv_buffer_state->draw_contour(*it);
-			}
+			m_opencv_buffer_state->draw_contour(*it);
 
 			// Convert integer contour to float
 			t_opencv_float_contour biggest_contour_f;
@@ -1473,10 +1442,7 @@ bool ServerTrackerView::computePoseForHMD(
 						out_pose_estimate);
 
 				//Draw results onto m_opencv_buffer_state
-				if (bShowDebugRendering)
-				{
-					m_opencv_buffer_state->draw_pose_projection(out_pose_estimate->projection);
-				}
+				m_opencv_buffer_state->draw_pose_projection(out_pose_estimate->projection);
 			} break;
 		default:
 			assert(0 && "Unreachable");

--- a/src/psmoveservice/Device/View/ServerTrackerView.h
+++ b/src/psmoveservice/Device/View/ServerTrackerView.h
@@ -25,7 +25,7 @@ public:
 
     // Starts or stops streaming of the video feed to the shared memory buffer.
     // Keep a ref count of how many clients are following the stream.
-    void startSharedMemoryVideoStream(bool include_debug_rendering);
+    void startSharedMemoryVideoStream();
     void stopSharedMemoryVideoStream();
 
     // Fetch the next video frame and copy to shared memory
@@ -132,8 +132,6 @@ public:
 	void setHMDTrackingColorPreset(const class ServerHMDView *controller, eCommonTrackingColorID color, const CommonHSVColorRange *preset);
 	void getHMDTrackingColorPreset(const class ServerHMDView *controller, eCommonTrackingColorID color, CommonHSVColorRange *out_preset) const;
 
-	inline bool getIsDebugRenderingEnabled() const { return m_include_debug_rendering_count > 0; }
-
 protected:
     bool allocate_device_interface(const class DeviceEnumerator *enumerator) override;
     void free_device_interface() override;
@@ -146,7 +144,6 @@ private:
     char m_shared_memory_name[256];
     class SharedVideoFrameReadWriteAccessor *m_shared_memory_accesor;
     int m_shared_memory_video_stream_count;
-	int m_include_debug_rendering_count;
     class OpenCVBufferState *m_opencv_buffer_state;
     ITrackerInterface *m_device;
 };

--- a/src/psmoveservice/Server/ServerRequestHandler.cpp
+++ b/src/psmoveservice/Server/ServerRequestHandler.cpp
@@ -1653,7 +1653,7 @@ protected:
                 streamInfo.streaming_video_data = true;
 
                 // Increment the number of stream listeners
-                tracker_view->startSharedMemoryVideoStream(request.include_debug_rendering());
+                tracker_view->startSharedMemoryVideoStream();
 
                 // Return the name of the shared memory block the video frames will be written to
                 response->set_result_code(PSMoveProtocol::Response_ResultCode_RESULT_OK);


### PR DESCRIPTION
I think I've successfully reverted the commit that added flags to the debug overlay.

Now the cross hairs shrink with the ellipse or rectangle that they are drawn in. I couldn't reduce the thickness as they were already set to the minimum but I think it looks okay.