### PR TITLE
Added the option to hide the setting windows during colour calibration

### DIFF
--- a/src/psmoveconfigtool/AppStage_ColorCalibration.cpp
+++ b/src/psmoveconfigtool/AppStage_ColorCalibration.cpp
@@ -149,6 +149,7 @@ AppStage_ColorCalibration::AppStage_ColorCalibration(App *app)
 	, m_bAutoChangeController(false)
 	, m_bAutoChangeColor(false)
 	, m_bAutoChangeTracker(false)
+	, m_bShowWindows(true)
     , m_masterTrackingColorType(PSMoveTrackingColorType::Magenta)
 { 
     memset(m_colorPresets, 0, sizeof(m_colorPresets));
@@ -378,6 +379,7 @@ void AppStage_ColorCalibration::renderUI()
     case eMenuState::manualConfig:
     {
         // Video Control Panel
+		if (m_bShowWindows)
         {
             ImGui::SetNextWindowPos(ImVec2(10.f, 10.f));
             ImGui::SetNextWindowSize(ImVec2(k_panel_width, 260));
@@ -410,7 +412,7 @@ void AppStage_ColorCalibration::renderUI()
                         (m_videoDisplayMode + 1) % eVideoDisplayMode::MAX_VIDEO_DISPLAY_MODES);
                 }
                 ImGui::SameLine();
-                ImGui::Text("Video Filter Mode: %s", k_video_display_mode_names[m_videoDisplayMode]);
+                ImGui::Text("Video [F]ilter Mode: %s", k_video_display_mode_names[m_videoDisplayMode]);
 				
 				int frame_rate_positive_change = 10;
 				int frame_rate_negative_change = -10;
@@ -537,7 +539,32 @@ void AppStage_ColorCalibration::renderUI()
 			}
 		}
 
+		// Keyboard shortcuts
+		{
+			// Hide setting windows: space bar
+			if (ImGui::IsKeyReleased(32)) m_bShowWindows = !m_bShowWindows;
+			// Change filter: F
+			if (ImGui::IsKeyReleased(102)) {
+				m_videoDisplayMode =
+					static_cast<eVideoDisplayMode>(
+					(m_videoDisplayMode + 1) % eVideoDisplayMode::MAX_VIDEO_DISPLAY_MODES);
+			}
+			// Change tracker: T
+			if (ImGui::IsKeyReleased(116)) request_change_tracker(1);
+			// Change controller: M
+			if (ImGui::IsKeyReleased(109)) request_change_controller(1);
+			// Change color: C
+			if (ImGui::IsKeyReleased(99)) {
+				PSMoveTrackingColorType new_color =
+					static_cast<PSMoveTrackingColorType>(
+					(m_masterTrackingColorType + 1) % PSMoveTrackingColorType::MAX_PSMOVE_COLOR_TYPES);
+				request_set_controller_tracking_color(m_masterControllerView, new_color);
+				m_masterTrackingColorType = new_color;
+			}
+		}
+
         // Color Control Panel
+		if (m_bShowWindows)
         {
             ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - k_panel_width - 10, 20.f));
             ImGui::SetNextWindowSize(ImVec2(k_panel_width, 280));
@@ -565,7 +592,7 @@ void AppStage_ColorCalibration::renderUI()
 				}
 				ImGui::SameLine();
 			}
-            ImGui::Text("Tracking Color: %s", k_tracking_color_names[m_masterTrackingColorType]);
+            ImGui::Text("Tracking [C]olor: %s", k_tracking_color_names[m_masterTrackingColorType]);
 
             // -- Hue --
             if (ImGui::Button("-##HueCenter"))
@@ -685,7 +712,7 @@ void AppStage_ColorCalibration::renderUI()
 				request_change_controller(1);
 			}
 			ImGui::SameLine();
-			ImGui::Text("Controller ID: %d", m_overrideControllerId);
+			ImGui::Text("PS[M]ove Controller ID: %d", m_overrideControllerId);
 
 			// -- Change Tracker --
 			if (ImGui::Button("<##Tracker"))
@@ -698,7 +725,7 @@ void AppStage_ColorCalibration::renderUI()
 				request_change_tracker(1);
 			}
 			ImGui::SameLine();
-			ImGui::Text("Tracker ID: %d", tracker_index);
+			ImGui::Text("[T]racker ID: %d", tracker_index);
 			
             ImGui::End();
         }

--- a/src/psmoveconfigtool/AppStage_ColorCalibration.h
+++ b/src/psmoveconfigtool/AppStage_ColorCalibration.h
@@ -192,6 +192,9 @@ private:
 	bool m_bAutoChangeController;
 	bool m_bAutoChangeColor;
 	bool m_bAutoChangeTracker;
+
+	// Setting Windows visability
+	bool m_bShowWindows;
 };
 
 #endif // APP_STAGE_COLOR_CALIBRATION_H


### PR DESCRIPTION
In some circumstances the setting windows may hide the controller or other
detected objects. To overcome this the windows can now be hidded by
pressing the space bar. Since this then removes direct access to some of
the funtions (like changing the filter) keyboard shortcuts have been added
to the more important ones (the letter used has been placed in square brackets).