### PR TITLE
Changed recenter controller button to Navi D-pad down if the PSMove has a PSNavi child

### DIFF
--- a/src/openvr_plugin/driver_psmoveservice.h
+++ b/src/openvr_plugin/driver_psmoveservice.h
@@ -292,6 +292,11 @@ private:
 
 	std::chrono::time_point<std::chrono::high_resolution_clock> m_resetPoseButtonPressTime;
 	bool m_bResetPoseRequestSent;
+	std::chrono::time_point<std::chrono::high_resolution_clock> m_resetAlignButtonPressTime;
+	bool m_bResetAlignRequestSent;
+
+	bool m_bUsePSNaviDPadRecenter;
+	bool m_bUsePSNaviDPadRealign;
 
     // Button Remapping
     vr::EVRButtonId psButtonIDToVRButtonID[k_EPSControllerType_Count][k_EPSButtonID_Count];


### PR DESCRIPTION
If the PSMove controller has a PSNavi child the recenter function of the
SELECT button is overrode by the D-pad down button of the PSNavi
controller. This makes it easier to access if the PSMove is paired with 
a PSNavi.

I'm not sure whether this should be merged as it is because it is not user 
adjustable. Since the PSNavi doesn't have any hard to reach buttons like 
the SELECT button would it be better to increase the required hold time 
for the PSNavi button mode?