### PR TITLE
Keep TriggerValue an unsigned char untill it is used

### DIFF
--- a/src/openvr_plugin/driver_psmoveservice.cpp
+++ b/src/openvr_plugin/driver_psmoveservice.cpp
@@ -2319,7 +2319,7 @@ void CPSMoveControllerLatest::UpdateControllerState()
 				}
 
 				// PSMove Trigger handling
-				NewState.rAxis[m_triggerAxisIndex].x = clientView.TriggerValue;
+				NewState.rAxis[m_triggerAxisIndex].x = clientView.TriggerValue / 255.f;
 				NewState.rAxis[m_triggerAxisIndex].y = 0.f;
 
 				// Attached PSNavi Trigger handling
@@ -2327,7 +2327,7 @@ void CPSMoveControllerLatest::UpdateControllerState()
 				{
 					const PSMPSNavi &naviClientView = m_PSMChildControllerView->ControllerState.PSNaviState;
 
-					NewState.rAxis[m_triggerAxisIndex].x = fmaxf(NewState.rAxis[m_triggerAxisIndex].x, naviClientView.TriggerValue);
+					NewState.rAxis[m_triggerAxisIndex].x = fmaxf(NewState.rAxis[m_triggerAxisIndex].x, naviClientView.TriggerValue / 255.f);
 				}
 
 				// Trigger SteamVR Events

--- a/src/psmoveclient/ClientControllerView.h
+++ b/src/psmoveclient/ClientControllerView.h
@@ -343,9 +343,9 @@ public:
 		return IsValid() ? BatteryValue : PSMoveBattery_0;
 	}
 
-    inline float GetTriggerValue() const
+    inline unsigned char GetTriggerValue() const
     {
-        return IsValid() ? ((float)TriggerValue / 255.f) : 0.f;
+        return IsValid() ? TriggerValue : 0;
     }
 
     inline float GetRumble() const
@@ -463,9 +463,9 @@ public:
         return IsValid() ? DPadLeftButton : PSMoveButton_UP;
     }
 
-    inline float GetTriggerValue() const
+    inline unsigned char GetTriggerValue() const
     {
-        return IsValid() ? ((float)TriggerValue / 255.f) : 0.f;
+        return IsValid() ? TriggerValue : 0;
     }
 
     inline float GetStickXAxis() const

--- a/src/psmoveclient/PSMoveClient_CAPI.cpp
+++ b/src/psmoveclient/PSMoveClient_CAPI.cpp
@@ -2300,7 +2300,7 @@ static void extractControllerState(const ClientControllerView *view, PSMControll
             controller->ControllerState.PSMoveState.MoveButton = static_cast<PSMButtonState>(psmview.GetButtonMove());
             controller->ControllerState.PSMoveState.TriggerButton = static_cast<PSMButtonState>(psmview.GetButtonTrigger());
             controller->ControllerState.PSMoveState.BatteryValue = static_cast<PSMBatteryState>(psmview.GetBatteryValue());
-            controller->ControllerState.PSMoveState.TriggerValue = static_cast<unsigned char>(psmview.GetTriggerValue() * 255.f);
+            controller->ControllerState.PSMoveState.TriggerValue = static_cast<unsigned char>(psmview.GetTriggerValue());
             controller->ControllerState.PSMoveState.Rumble = static_cast<unsigned char>(psmview.GetRumble() * 255.f);
             break;
             
@@ -2318,7 +2318,7 @@ static void extractControllerState(const ClientControllerView *view, PSMControll
 			controller->ControllerState.PSNaviState.DPadRightButton = static_cast<PSMButtonState>(psnview.GetButtonDPadRight());
 			controller->ControllerState.PSNaviState.DPadDownButton = static_cast<PSMButtonState>(psnview.GetButtonDPadDown());
 			controller->ControllerState.PSNaviState.DPadLeftButton = static_cast<PSMButtonState>(psnview.GetButtonDPadLeft());
-			controller->ControllerState.PSNaviState.TriggerValue = static_cast<unsigned char>(psnview.GetTriggerValue() * 255.f);
+			controller->ControllerState.PSNaviState.TriggerValue = static_cast<unsigned char>(psnview.GetTriggerValue());
 			controller->ControllerState.PSNaviState.Stick_XAxis= psnview.GetStickXAxis();
 			controller->ControllerState.PSNaviState.Stick_YAxis= psnview.GetStickYAxis();;
             break;


### PR DESCRIPTION
The TriggerValue for the PSMove and PSNavi were getting converted back
and forth between an unsigned char and a normalised float. To make it
simpler keep it as an unsigned char untill it needs to be read by a
program at which point it can be converted.

This will probably cause a problem for the PSMoveFreepieBridge but that
will need to be ungraded for the CAPI anyway.