### PR TITLE
Rotated acceleration vector for world view of test accelerometer

### DIFF
--- a/src/psmoveconfigtool/AppStage_AccelerometerCalibration.cpp
+++ b/src/psmoveconfigtool/AppStage_AccelerometerCalibration.cpp
@@ -320,9 +320,11 @@ void AppStage_AccelerometerCalibration::render()
 					}
 
 					glm::mat4 worldSpaceOrientation = glm::mat4_cast(q);
-
+					
 					controllerTransform = glm::scale(worldSpaceOrientation, glm::vec3(k_modelScale, k_modelScale, k_modelScale));
-					sensorTransform = glm::scale(worldSpaceOrientation, glm::vec3(k_sensorScale, k_sensorScale, k_sensorScale));
+					sensorTransform = glm::rotate(
+						glm::scale(worldSpaceOrientation, glm::vec3(k_sensorScale, k_sensorScale, k_sensorScale)),
+						-90.f, glm::vec3(1.f, 0.f, 0.f));
 				} break;
 			default:
 				assert(0 && "unreachable");


### PR DESCRIPTION
The acceleration vector was not properly set for the world view mode
of test accelerometer in the config tool. It had to be rotated by -90
deg (ie. oposite to how the defaultControllerTransform is set for the
PSMove controller model). The acceleration vector now always points up if
the controller is at rest in the world's frame of reference.