### PR TITLE
Fixed the serial number handling

### DIFF
--- a/src/openvr_plugin/driver_psmoveservice.cpp
+++ b/src/openvr_plugin/driver_psmoveservice.cpp
@@ -677,7 +677,7 @@ void CServerDriver_PSMoveService::HandleControllerListReponse(
     {
         int controller_id = controller_list->controller_id[list_index];
         PSMControllerType controller_type = controller_list->controller_type[list_index];
-		std::string ControllerSerial(&controller_list->controller_serial[list_index]);
+		std::string ControllerSerial(controller_list->controller_serial[list_index]);
 
         switch (controller_type)
         {
@@ -704,8 +704,8 @@ void CServerDriver_PSMoveService::HandleControllerListReponse(
 		{
 			int controller_id = controller_list->controller_id[list_index];
 			PSMControllerType controller_type = controller_list->controller_type[list_index];
-			std::string ControllerSerial(&controller_list->controller_serial[list_index]);
-			std::string ParentControllerSerial(&controller_list->parent_controller_serial[list_index]);
+			std::string ControllerSerial(controller_list->controller_serial[list_index]);
+			std::string ParentControllerSerial(controller_list->parent_controller_serial[list_index]);
 
 			if (controller_type == PSMControllerType::PSMController_Navi)
 			{
@@ -2074,7 +2074,7 @@ void CPSMoveControllerLatest::UpdateControllerState()
 			// Check if the PSMove has a PSNavi child
 			const bool bHasChildNavi= 
 				m_PSMChildControllerView != nullptr && 
-				m_PSMChildControllerView->ControllerType == PSMController_Move;
+				m_PSMChildControllerView->ControllerType == PSMController_Navi;
 
 			// See if the recenter button has been held for the requisite amount of time
 			bool bRecenterRequestTriggered = false;

--- a/src/psmoveclient/ClientPSMoveAPI.h
+++ b/src/psmoveclient/ClientPSMoveAPI.h
@@ -115,8 +115,8 @@ public:
     {
         int controller_id[PSMOVESERVICE_MAX_CONTROLLER_COUNT];
         ClientControllerView::eControllerType controller_type[PSMOVESERVICE_MAX_CONTROLLER_COUNT];
-        char controller_serial[PSMOVESERVICE_CONTROLLER_SERIAL_LEN];
-        char parent_controller_serial[PSMOVESERVICE_CONTROLLER_SERIAL_LEN];
+        char controller_serial[PSMOVESERVICE_MAX_CONTROLLER_COUNT][PSMOVESERVICE_CONTROLLER_SERIAL_LEN];
+        char parent_controller_serial[PSMOVESERVICE_MAX_CONTROLLER_COUNT][PSMOVESERVICE_CONTROLLER_SERIAL_LEN];
         int count;
     };
 

--- a/src/psmoveclient/ClientRequestManager.cpp
+++ b/src/psmoveclient/ClientRequestManager.cpp
@@ -239,8 +239,8 @@ public:
                 // Add an entry to the controller list
                 controller_list->controller_type[dest_controller_count] = controllerType;
                 controller_list->controller_id[dest_controller_count] = ControllerResponse.controller_id();
-				strncpy(&controller_list->controller_serial[dest_controller_count], ControllerResponse.device_serial().c_str(), PSMOVESERVICE_CONTROLLER_SERIAL_LEN);
-				strncpy(&controller_list->parent_controller_serial[dest_controller_count], ControllerResponse.parent_controller_serial().c_str(), PSMOVESERVICE_CONTROLLER_SERIAL_LEN);
+				strncpy(controller_list->controller_serial[dest_controller_count], ControllerResponse.device_serial().c_str(), PSMOVESERVICE_CONTROLLER_SERIAL_LEN);
+				strncpy(controller_list->parent_controller_serial[dest_controller_count], ControllerResponse.parent_controller_serial().c_str(), PSMOVESERVICE_CONTROLLER_SERIAL_LEN);
                 ++dest_controller_count;
             }
 

--- a/src/psmoveclient/PSMoveClient_CAPI.h
+++ b/src/psmoveclient/PSMoveClient_CAPI.h
@@ -439,8 +439,8 @@ typedef struct _PSMControllerList
 {
     PSMControllerID controller_id[PSMOVESERVICE_MAX_CONTROLLER_COUNT];
     PSMControllerType controller_type[PSMOVESERVICE_MAX_CONTROLLER_COUNT];
-	char controller_serial[PSMOVESERVICE_CONTROLLER_SERIAL_LEN];
-	char parent_controller_serial[PSMOVESERVICE_CONTROLLER_SERIAL_LEN];
+	char controller_serial[PSMOVESERVICE_MAX_CONTROLLER_COUNT][PSMOVESERVICE_CONTROLLER_SERIAL_LEN];
+	char parent_controller_serial[PSMOVESERVICE_MAX_CONTROLLER_COUNT][PSMOVESERVICE_CONTROLLER_SERIAL_LEN];
     int count;
 } PSMControllerList;
 

--- a/src/psmoveservice/Device/View/ServerControllerView.cpp
+++ b/src/psmoveservice/Device/View/ServerControllerView.cpp
@@ -747,7 +747,7 @@ ServerControllerView::getProductID() const
 std::string 
 ServerControllerView::getSerial() const
 {
-    return(m_device != nullptr) ? m_device->getSerial() : "";
+    return (m_device != nullptr) ? m_device->getSerial() : "";
 }
 
 // Returns the "controller_" + serial number for the controller


### PR DESCRIPTION
Previously only one serial number was kept in the list (it wasn't an
actual list). This was the case for both the controller_serial list and
the parent_controller_serial list.

The PSNavi child check was also fixed. It was checking if it was a
PSMove instead of a PSNavi.