### PR TITLE
Added the option to assign a button to the diagonals of the touchpad

### DIFF
--- a/src/openvr_plugin/driver_psmoveservice.cpp
+++ b/src/openvr_plugin/driver_psmoveservice.cpp
@@ -129,6 +129,10 @@ static const char *k_VRTouchpadDirectionNames[k_max_vr_touchpad_directions] = {
 	"touchpad_up",
 	"touchpad_right",
 	"touchpad_down",
+	"touchpad_up-left",
+	"touchpad_up-right",
+	"touchpad_down-left",
+	"touchpad_down-right",
 };
 
 //==================================================================================================
@@ -2563,6 +2567,34 @@ void CPSMoveControllerLatest::UpdateControllerStateFromPsMoveButtonState(
 			{
 				m_touchpadDirectionsUsed = true;
 				pControllerStateToUpdate->rAxis[0].y = -1.0f;
+				pControllerStateToUpdate->ulButtonPressed |= vr::ButtonMaskFromId(vr::k_EButton_SteamVR_Touchpad);
+			}
+			else if (psButtonIDToVrTouchpadDirection[controllerType][buttonId] == k_EVRTouchpadDirection_UpLeft)
+			{
+				m_touchpadDirectionsUsed = true;
+				pControllerStateToUpdate->rAxis[0].x = -0.707f;
+				pControllerStateToUpdate->rAxis[0].y = 0.707f;
+				pControllerStateToUpdate->ulButtonPressed |= vr::ButtonMaskFromId(vr::k_EButton_SteamVR_Touchpad);
+			}
+			else if (psButtonIDToVrTouchpadDirection[controllerType][buttonId] == k_EVRTouchpadDirection_UpRight)
+			{
+				m_touchpadDirectionsUsed = true;
+				pControllerStateToUpdate->rAxis[0].x = 0.707f;
+				pControllerStateToUpdate->rAxis[0].y = 0.707f;
+				pControllerStateToUpdate->ulButtonPressed |= vr::ButtonMaskFromId(vr::k_EButton_SteamVR_Touchpad);
+			}
+			else if (psButtonIDToVrTouchpadDirection[controllerType][buttonId] == k_EVRTouchpadDirection_DownLeft)
+			{
+				m_touchpadDirectionsUsed = true;
+				pControllerStateToUpdate->rAxis[0].x = -0.707f;
+				pControllerStateToUpdate->rAxis[0].y = -0.707f;
+				pControllerStateToUpdate->ulButtonPressed |= vr::ButtonMaskFromId(vr::k_EButton_SteamVR_Touchpad);
+			}
+			else if (psButtonIDToVrTouchpadDirection[controllerType][buttonId] == k_EVRTouchpadDirection_DownRight)
+			{
+				m_touchpadDirectionsUsed = true;
+				pControllerStateToUpdate->rAxis[0].x = 0.707f;
+				pControllerStateToUpdate->rAxis[0].y = -0.707f;
 				pControllerStateToUpdate->ulButtonPressed |= vr::ButtonMaskFromId(vr::k_EButton_SteamVR_Touchpad);
 			}
 		}

--- a/src/openvr_plugin/driver_psmoveservice.h
+++ b/src/openvr_plugin/driver_psmoveservice.h
@@ -200,6 +200,11 @@ public:
 		k_EVRTouchpadDirection_Right,
 		k_EVRTouchpadDirection_Down,
 
+		k_EVRTouchpadDirection_UpLeft,
+		k_EVRTouchpadDirection_UpRight,
+		k_EVRTouchpadDirection_DownLeft,
+		k_EVRTouchpadDirection_DownRight,
+
 		k_EVRTouchpadDirection_Count
 	};
 


### PR DESCRIPTION
The button mapping options for the touchpad directions was limited to
up/down/left/right. This adds the diagonal combinations as possible
mapping options.