### PR TITLE
Add PSEye resolution control

### DIFF
--- a/src/psmoveconfigtool/AppStage_ColorCalibration.cpp
+++ b/src/psmoveconfigtool/AppStage_ColorCalibration.cpp
@@ -142,7 +142,8 @@ AppStage_ColorCalibration::AppStage_ColorCalibration(App *app)
     , m_menuState(AppStage_ColorCalibration::inactive)
     , m_video_buffer_state(nullptr)
     , m_videoDisplayMode(AppStage_ColorCalibration::eVideoDisplayMode::mode_bgr)
-	, m_trackerFramerate(0)
+	, m_trackerFrameWidth(0)
+	, m_trackerFrameRate(0)
     , m_trackerExposure(0)
     , m_trackerGain(0)
 	, m_bTurnOnAllControllers(false)
@@ -386,7 +387,7 @@ void AppStage_ColorCalibration::renderUI()
 		if (m_bShowWindows)
         {
             ImGui::SetNextWindowPos(ImVec2(10.f, 10.f));
-            ImGui::SetNextWindowSize(ImVec2(k_panel_width, 260));
+            ImGui::SetNextWindowSize(ImVec2(k_panel_width, 280));
             ImGui::Begin(k_window_title, nullptr, window_flags);
 
 			if (ImGui::Button("Return to Main Menu"))
@@ -417,36 +418,75 @@ void AppStage_ColorCalibration::renderUI()
                 }
                 ImGui::SameLine();
                 ImGui::Text("Video [F]ilter Mode: %s", k_video_display_mode_names[m_videoDisplayMode]);
+
+				if (ImGui::Button("-##FrameWidth"))
+				{
+					if (m_trackerFrameWidth == 640) request_tracker_set_frame_width(m_trackerFrameWidth - 320);
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("+##FrameWidth"))
+				{
+					if (m_trackerFrameWidth == 320) request_tracker_set_frame_width(m_trackerFrameWidth + 320);
+				}
+				ImGui::SameLine();
+				ImGui::Text("Frame Width: %.0f", m_trackerFrameWidth);
 				
 				int frame_rate_positive_change = 10;
 				int frame_rate_negative_change = -10;
 				
-				double val = m_trackerFramerate;
-
-				if (val == 2) { frame_rate_positive_change = 1; frame_rate_negative_change = 0; }
-				else if (val == 3) { frame_rate_positive_change = 2; frame_rate_negative_change = -1; }
-				else if (val == 5) { frame_rate_positive_change = 3; frame_rate_negative_change = -0; }
-				else if (val == 8) { frame_rate_positive_change = 2; frame_rate_negative_change = -3; }
-				else if (val == 10) { frame_rate_positive_change = 5; frame_rate_negative_change = -2; }
-				else if (val == 15) { frame_rate_positive_change = 5; frame_rate_negative_change = -5; }
-				else if (val == 20) { frame_rate_positive_change = 5; frame_rate_negative_change = -5; }
-				else if (val == 25) { frame_rate_positive_change = 5; frame_rate_negative_change = -5; }
-				else if (val == 30) { { frame_rate_negative_change = -5; } }
-				else if (val == 60) { { frame_rate_positive_change = 15; } }
-				else if (val == 75) { frame_rate_positive_change = 0; frame_rate_negative_change = -15; }
-				else if (val == 83) { frame_rate_positive_change = 0; frame_rate_negative_change = -8; }
-
-				if (ImGui::Button("-##Framerate"))
+				double val = m_trackerFrameRate;
+				if (m_trackerFrameWidth == 320) 
 				{
-					request_tracker_set_frame_rate(m_trackerFramerate + frame_rate_negative_change);
+					if (val == 2) { frame_rate_positive_change = 1; frame_rate_negative_change = 0; }
+					else if (val == 3) { frame_rate_positive_change = 2; frame_rate_negative_change = -1; }
+					else if (val == 5) { frame_rate_positive_change = 2; frame_rate_negative_change = -0; }
+					else if (val == 7) { frame_rate_positive_change = 3; frame_rate_negative_change = -2; }
+					else if (val == 10) { frame_rate_positive_change = 2; frame_rate_negative_change = -3; }
+					else if (val == 12) { frame_rate_positive_change = 3; frame_rate_negative_change = -2; }
+					else if (val == 15) { frame_rate_positive_change = 4; frame_rate_negative_change = -3; }
+					else if (val == 17) { frame_rate_positive_change = 13; frame_rate_negative_change = -4; }
+					else if (val == 30) { frame_rate_positive_change = 7; frame_rate_negative_change = -13; }
+					else if (val == 37) { frame_rate_positive_change = 3; frame_rate_negative_change = -7; }
+					else if (val == 40) { frame_rate_positive_change = 10; frame_rate_negative_change = -3; }
+					else if (val == 50) { frame_rate_positive_change = 10; frame_rate_negative_change = -10; }
+					else if (val == 60) { frame_rate_positive_change = 15; frame_rate_negative_change = -10; }
+					else if (val == 75) { frame_rate_positive_change = 15; frame_rate_negative_change = -15; }
+					else if (val == 90) { frame_rate_positive_change = 10; frame_rate_negative_change = -15; }
+					else if (val == 100) { frame_rate_positive_change = 25; frame_rate_negative_change = -10; }
+					else if (val == 125) { frame_rate_positive_change = 12; frame_rate_negative_change = -25; }
+					else if (val == 137) { frame_rate_positive_change = 13; frame_rate_negative_change = -12; }
+					else if (val == 150) { frame_rate_positive_change = 37; frame_rate_negative_change = -13; }
+					else if (val == 187) { frame_rate_positive_change = 0; frame_rate_negative_change = -37; }
+					else if (val == 205) { frame_rate_positive_change = 0; frame_rate_negative_change = -18; }
+					else if (val == 290) { frame_rate_positive_change = 0; frame_rate_negative_change = -85; }
+				}
+				else 
+				{
+					if (val == 2) { frame_rate_positive_change = 1; frame_rate_negative_change = 0; }
+					else if (val == 3) { frame_rate_positive_change = 2; frame_rate_negative_change = -1; }
+					else if (val == 5) { frame_rate_positive_change = 3; frame_rate_negative_change = -0; }
+					else if (val == 8) { frame_rate_positive_change = 2; frame_rate_negative_change = -3; }
+					else if (val == 10) { frame_rate_positive_change = 5; frame_rate_negative_change = -2; }
+					else if (val == 15) { frame_rate_positive_change = 5; frame_rate_negative_change = -5; }
+					else if (val == 20) { frame_rate_positive_change = 5; frame_rate_negative_change = -5; }
+					else if (val == 25) { frame_rate_positive_change = 5; frame_rate_negative_change = -5; }
+					else if (val == 30) { { frame_rate_negative_change = -5; } }
+					else if (val == 60) { { frame_rate_positive_change = 15; } }
+					else if (val == 75) { frame_rate_positive_change = 0; frame_rate_negative_change = -15; }
+					else if (val == 83) { frame_rate_positive_change = 0; frame_rate_negative_change = -8; }
+				}
+
+				if (ImGui::Button("-##FrameRate"))
+				{
+					request_tracker_set_frame_rate(m_trackerFrameRate + frame_rate_negative_change);
 				}
 				ImGui::SameLine();
-				if (ImGui::Button("+##Framerate"))
+				if (ImGui::Button("+##FrameRate"))
 				{
-					request_tracker_set_frame_rate(m_trackerFramerate + frame_rate_positive_change);
+					request_tracker_set_frame_rate(m_trackerFrameRate + frame_rate_positive_change);
 				}
 				ImGui::SameLine();
-				ImGui::Text("Framerate: %.0f", m_trackerFramerate);
+				ImGui::Text("Frame Rate: %.0f", m_trackerFrameRate);
 
                 if (ImGui::Button("-##Exposure"))
                 {
@@ -768,14 +808,10 @@ void AppStage_ColorCalibration::renderUI()
 	} break;
 
 	case eMenuState::blank1:
-		setState(eMenuState::blank3);
-		std::this_thread::sleep_for(std::chrono::milliseconds(auto_calib_sleep));
-		break;
-	case eMenuState::blank2:
 		setState(eMenuState::blank2);
 		std::this_thread::sleep_for(std::chrono::milliseconds(auto_calib_sleep));
 		break;
-	case eMenuState::blank3:
+	case eMenuState::blank2:
 		setState(eMenuState::autoConfig);
 		std::this_thread::sleep_for(std::chrono::milliseconds(auto_calib_sleep));
 		break;
@@ -1026,11 +1062,54 @@ void AppStage_ColorCalibration::release_video_buffers()
     m_video_buffer_state = nullptr;
 }
 
+void AppStage_ColorCalibration::request_tracker_set_frame_width(double value)
+{
+	// Tell the psmove service that we want to change frame width.
+	RequestPtr request(new PSMoveProtocol::Request());
+	request->set_type(PSMoveProtocol::Request_RequestType_SET_TRACKER_FRAME_WIDTH);
+	request->mutable_request_set_tracker_frame_width()->set_tracker_id(m_trackerView->tracker_info.tracker_id);
+	request->mutable_request_set_tracker_frame_width()->set_value(static_cast<float>(value));
+	request->mutable_request_set_tracker_frame_width()->set_save_setting(true);
+
+	PSMRequestID request_id;
+	PSM_SendOpaqueRequest(&request, &request_id);
+	PSM_RegisterCallback(request_id, AppStage_ColorCalibration::handle_tracker_set_frame_width_response, this);
+
+	// Exit and re-enter Color Calibration
+	m_app->getAppStage<AppStage_TrackerSettings>()->gotoColorCalib();
+	request_exit_to_app_stage(AppStage_TrackerSettings::APP_STAGE_NAME);
+}
+
+void AppStage_ColorCalibration::handle_tracker_set_frame_width_response(
+	const PSMResponseMessage *response,
+	void *userdata)
+{
+	PSMResult ResultCode = response->result_code;
+	PSMResponseHandle response_handle = response->opaque_response_handle;
+	AppStage_ColorCalibration *thisPtr = static_cast<AppStage_ColorCalibration *>(userdata);
+
+	switch (ResultCode)
+	{
+	case PSMResult_Success:
+	{
+		const PSMoveProtocol::Response *response = GET_PSMOVEPROTOCOL_RESPONSE(response_handle);
+		thisPtr->m_trackerFrameWidth = response->result_set_tracker_frame_width().new_frame_width();
+	} break;
+	case PSMResult_Error:
+	case PSMResult_Canceled:
+	case PSMResult_Timeout:
+	{
+		//###HipsterSloth $TODO - Replace with C_API style log
+		//CLIENT_LOG_INFO("AppStage_ColorCalibration") << "Failed to set the tracker frame width!";
+	} break;
+	}
+}
+
 void AppStage_ColorCalibration::request_tracker_set_frame_rate(double value)
 {
 	// Tell the psmove service that we want to change frame rate.
 	RequestPtr request(new PSMoveProtocol::Request());
-	request->set_type(PSMoveProtocol::Request_RequestType_SET_TRACKER_FRAMERATE);
+	request->set_type(PSMoveProtocol::Request_RequestType_SET_TRACKER_FRAME_RATE);
 	request->mutable_request_set_tracker_frame_rate()->set_tracker_id(m_trackerView->tracker_info.tracker_id);
 	request->mutable_request_set_tracker_frame_rate()->set_value(static_cast<float>(value));
 	request->mutable_request_set_tracker_frame_rate()->set_save_setting(true);
@@ -1053,7 +1132,7 @@ void AppStage_ColorCalibration::handle_tracker_set_frame_rate_response(
 	case PSMResult_Success:
 		{
 			const PSMoveProtocol::Response *response = GET_PSMOVEPROTOCOL_RESPONSE(response_handle);
-			thisPtr->m_trackerFramerate = response->result_set_tracker_frame_rate().new_frame_rate();
+			thisPtr->m_trackerFrameRate = response->result_set_tracker_frame_rate().new_frame_rate();
 		} break;
 	case PSMResult_Error:
 	case PSMResult_Canceled:
@@ -1307,7 +1386,8 @@ void AppStage_ColorCalibration::handle_tracker_get_settings_response(
     case PSMResult_Success:
         {
             const PSMoveProtocol::Response *response = GET_PSMOVEPROTOCOL_RESPONSE(response_handle);
-			thisPtr->m_trackerFramerate = response->result_tracker_settings().frame_rate();
+			thisPtr->m_trackerFrameWidth = response->result_tracker_settings().frame_width();
+			thisPtr->m_trackerFrameRate = response->result_tracker_settings().frame_rate();
             thisPtr->m_trackerExposure = response->result_tracker_settings().exposure();
             thisPtr->m_trackerGain = response->result_tracker_settings().gain();
 
@@ -1496,7 +1576,7 @@ void AppStage_ColorCalibration::request_change_controller(int step)
 void AppStage_ColorCalibration::request_change_tracker(int step)
 {
 	m_app->getAppStage<AppStage_ColorCalibration>()->
-	set_autoConfig(m_bAutoChangeColor, m_bAutoChangeController, m_bAutoChangeTracker);
+		set_autoConfig(m_bAutoChangeColor, m_bAutoChangeController, m_bAutoChangeTracker);
 	//int TrackerId = m_trackerView->tracker_info.tracker_id;
 	if (tracker_index + step < tracker_count && tracker_index + step >= 0)
 	{

--- a/src/psmoveconfigtool/AppStage_ColorCalibration.h
+++ b/src/psmoveconfigtool/AppStage_ColorCalibration.h
@@ -48,7 +48,6 @@ protected:
 		autoConfig,
 		blank1,
 		blank2,
-		blank3,
 		changeController,
 		changeTracker,
 
@@ -107,6 +106,11 @@ protected:
         const PSMResponseMessage *response,
         void *userdata);
 
+	void request_tracker_set_frame_width(double value);
+	static void handle_tracker_set_frame_width_response(
+		const PSMResponseMessage *response,
+		void *userdata);
+
 	void request_tracker_set_frame_rate(double value);
 	static void handle_tracker_set_frame_rate_response(
 		const PSMResponseMessage *response,
@@ -150,6 +154,7 @@ protected:
 
 	void request_change_controller(int step);
 	void request_change_tracker(int step);
+	void request_refresh_tracker();
 
     inline TrackerColorPreset getColorPreset()
     { return m_colorPresets[m_masterTrackingColorType]; }
@@ -176,7 +181,8 @@ private:
     eVideoDisplayMode m_videoDisplayMode;
 
     // Tracker Settings state
-	double m_trackerFramerate;
+	double m_trackerFrameWidth;
+	double m_trackerFrameRate;
     double m_trackerExposure;
     double m_trackerGain;
     std::vector<TrackerOption> m_trackerOptions;

--- a/src/psmoveconfigtool/AppStage_TrackerSettings.cpp
+++ b/src/psmoveconfigtool/AppStage_TrackerSettings.cpp
@@ -28,6 +28,7 @@ AppStage_TrackerSettings::AppStage_TrackerSettings(App *app)
     , m_selectedTrackerIndex(-1)
 	, m_selectedControllerIndex(-1)
 	, m_selectedHmdIndex(-1)
+	, m_gotoColorCalib(false)
 { }
 
 void AppStage_TrackerSettings::enter()
@@ -329,7 +330,7 @@ void AppStage_TrackerSettings::renderUI()
 
 					if (m_app->getIsLocalServer())
 					{
-						if (ImGui::Button("Calibrate Controller Tracking Colors"))
+						if (ImGui::Button("Calibrate Controller Tracking Colors") || m_gotoColorCalib)
 						{
 							const ControllerInfo *controller = get_selected_controller();
 							if (controller != NULL) {

--- a/src/psmoveconfigtool/AppStage_TrackerSettings.h
+++ b/src/psmoveconfigtool/AppStage_TrackerSettings.h
@@ -49,6 +49,8 @@ public:
 
     static const char *APP_STAGE_NAME;
 
+	void gotoColorCalib() { m_gotoColorCalib = true; }
+
 protected:
     virtual bool onClientAPIEvent(
         PSMEventMessage::eEventType event, 
@@ -97,6 +99,8 @@ protected:
     int m_selectedTrackerIndex;
 	int m_selectedControllerIndex;
 	int m_selectedHmdIndex;
+
+	bool m_gotoColorCalib;
 };
 
 #endif // APP_STAGE_TRACKER_SETTINGS_H

--- a/src/psmoveprotocol/PSMoveProtocol.proto
+++ b/src/psmoveprotocol/PSMoveProtocol.proto
@@ -152,7 +152,9 @@ message Request {
 
         GET_SERVICE_VERSION= 39;
 
-        SET_TRACKER_FRAMERATE = 40;
+        SET_TRACKER_FRAME_RATE = 40;
+        SET_TRACKER_FRAME_WIDTH = 41;
+        SET_TRACKER_FRAME_HEIGHT = 42;
     }
     RequestType type = 2;
 
@@ -439,13 +441,29 @@ message Request {
     }
     RequestSetHMDPredictionTime request_set_hmd_prediction_time = 37;
 
-    // Parameters for SET_TRACKER_FRAMERATE
-    message RequestSetTrackerFramerate {
+    // Parameters for SET_TRACKER_FRAME_RATE
+    message RequestSetTrackerFrameRate {
         int32 tracker_id = 1;
         float value = 2;
         bool save_setting= 3;
     }
-    RequestSetTrackerFramerate request_set_tracker_frame_rate = 38;
+    RequestSetTrackerFrameRate request_set_tracker_frame_rate = 38;
+
+    // Parameters for SET_TRACKER_FRAME_WIDTH
+    message RequestSetTrackerFrameWidth {
+        int32 tracker_id = 1;
+        float value = 2;
+        bool save_setting= 3;
+    }
+    RequestSetTrackerFrameWidth request_set_tracker_frame_width = 39;
+
+    // Parameters for SET_TRACKER_FRAME_HEIGHT
+    message RequestSetTrackerFrameHeight {
+        int32 tracker_id = 1;
+        float value = 2;
+        bool save_setting= 3;
+    }
+    RequestSetTrackerFrameHeight request_set_tracker_frame_height = 40;
 }
 
 // Reliable (TCP) responses to requests
@@ -471,7 +489,9 @@ message Response {
         HMD_LIST= 16;
         HMD_LIST_UPDATED= 17;
         SERVICE_VERSION= 18;
-        TRACKER_FRAMERATE_UPDATED= 19;
+        TRACKER_FRAME_RATE_UPDATED= 19;
+        TRACKER_FRAME_WIDTH_UPDATED= 20;
+        TRACKER_FRAME_HEIGHT_UPDATED= 21;
     }
 
     enum ResultCode {
@@ -584,6 +604,8 @@ message Response {
         repeated OptionSet option_sets= 3;
         repeated TrackingColorPreset color_presets = 4;
         float frame_rate= 5;
+        float frame_width= 6;
+        float frame_height= 7;
     }
     ResultTrackerSettings result_tracker_settings = 25;
 
@@ -642,11 +664,23 @@ message Response {
     }
     ResultServiceVersion result_service_version = 32;
 
-    // This is returned in response to a SET_TRACKER_FRAMERATE request
-    message ResultSetTrackerFramerate {
+    // This is returned in response to a SET_TRACKER_FRAME_RATE request
+    message ResultSetTrackerFrameRate {
         float new_frame_rate= 1;
     }
-    ResultSetTrackerFramerate result_set_tracker_frame_rate = 33;
+    ResultSetTrackerFrameRate result_set_tracker_frame_rate = 33;
+
+    // This is returned in response to a SET_TRACKER_FRAME_WIDTH request
+    message ResultSetTrackerFrameWidth {
+        float new_frame_width= 1;
+    }
+    ResultSetTrackerFrameWidth result_set_tracker_frame_width = 34;
+
+    // This is returned in response to a SET_TRACKER_FRAME_HEIGHT request
+    message ResultSetTrackerFrameHeight {
+        float new_frame_height= 1;
+    }
+    ResultSetTrackerFrameHeight result_set_tracker_frame_height = 35;
 }
 
 // Unreliable (UDP) device data packet sent from service to clients

--- a/src/psmoveservice/Device/Interface/DeviceInterface.h
+++ b/src/psmoveservice/Device/Interface/DeviceInterface.h
@@ -546,8 +546,14 @@ public:
     virtual void loadSettings() = 0;
     virtual void saveSettings() = 0;
 
-	virtual void setFramerate(double value, bool bUpdateConfig) = 0;
-	virtual double getFramerate() const = 0;
+	virtual void setFrameWidth(double value, bool bUpdateConfig) = 0;
+	virtual double getFrameWidth() const = 0;
+
+	virtual void setFrameHeight(double value, bool bUpdateConfig) = 0;
+	virtual double getFrameHeight() const = 0;
+
+	virtual void setFrameRate(double value, bool bUpdateConfig) = 0;
+	virtual double getFrameRate() const = 0;
 
     virtual void setExposure(double value, bool bUpdateConfig) = 0;
     virtual double getExposure() const = 0;

--- a/src/psmoveservice/Device/Manager/TrackerManager.cpp
+++ b/src/psmoveservice/Device/Manager/TrackerManager.cpp
@@ -24,6 +24,8 @@ TrackerManagerConfig::TrackerManagerConfig(const std::string &fnamebase)
 	exclude_opposed_cameras = false;
 	min_valid_projection_area= 16;
 	disable_roi = false;
+	default_tracker_profile.frame_width = 640;
+	//default_tracker_profile.frame_height = 480;
 	default_tracker_profile.frame_rate = 40;
     default_tracker_profile.exposure = 32;
     default_tracker_profile.gain = 32;
@@ -54,6 +56,8 @@ TrackerManagerConfig::config2ptree()
 
 	pt.put("disable_roi", disable_roi);
 
+	pt.put("default_tracker_profile.frame_width", default_tracker_profile.frame_width);
+	//pt.put("default_tracker_profile.frame_height", default_tracker_profile.frame_height);
 	pt.put("default_tracker_profile.frame_rate", default_tracker_profile.frame_rate);
     pt.put("default_tracker_profile.exposure", default_tracker_profile.exposure);
     pt.put("default_tracker_profile.gain", default_tracker_profile.gain);
@@ -80,6 +84,8 @@ TrackerManagerConfig::ptree2config(const boost::property_tree::ptree &pt)
 		exclude_opposed_cameras = pt.get<bool>("excluded_opposed_cameras", exclude_opposed_cameras);
 		min_valid_projection_area = pt.get<float>("min_valid_projection_area", min_valid_projection_area);	
 		disable_roi = pt.get<bool>("disable_roi", disable_roi);
+		default_tracker_profile.frame_width = pt.get<float>("default_tracker_profile.frame_width", 640);
+		//default_tracker_profile.frame_height = pt.get<float>("default_tracker_profile.frame_height", 480);
 		default_tracker_profile.frame_rate = pt.get<float>("default_tracker_profile.frame_rate", 40);
         default_tracker_profile.exposure = pt.get<float>("default_tracker_profile.exposure", 32);
         default_tracker_profile.gain = pt.get<float>("default_tracker_profile.gain", 32);

--- a/src/psmoveservice/Device/Manager/TrackerManager.h
+++ b/src/psmoveservice/Device/Manager/TrackerManager.h
@@ -16,6 +16,8 @@ typedef std::shared_ptr<ServerTrackerView> ServerTrackerViewPtr;
 //-- definitions -----
 struct TrackerProfile
 {
+	float frame_width;
+	//float frame_height;
 	float frame_rate;
 	float exposure;
     float gain;
@@ -23,6 +25,8 @@ struct TrackerProfile
 
     inline void clear()
     {
+		frame_width = 0.f;
+		// frame_height = 0.f;
 		frame_rate = 0.f;
 		exposure = 0.f;
         gain = 0;

--- a/src/psmoveservice/Device/View/ServerTrackerView.h
+++ b/src/psmoveservice/Device/View/ServerTrackerView.h
@@ -48,8 +48,14 @@ public:
     void loadSettings();
     void saveSettings();
 
-	double getFramerate() const;
-	void setFramerate(double value, bool bUpdateConfig);
+	double getFrameWidth() const;
+	void setFrameWidth(double value, bool bUpdateConfig);
+
+	double getFrameHeight() const;
+	void setFrameHeight(double value, bool bUpdateConfig);
+
+	double getFrameRate() const;
+	void setFrameRate(double value, bool bUpdateConfig);
 
     double getExposure() const;
     void setExposure(double value, bool bUpdateConfig);

--- a/src/psmoveservice/PSMoveTracker/PS3EyeTracker.h
+++ b/src/psmoveservice/PSMoveTracker/PS3EyeTracker.h
@@ -37,6 +37,8 @@ public:
     
     bool is_valid;
     long max_poll_failure_count;
+	double frame_width;
+	double frame_height;
 	double frame_rate;
     double exposure;
 	double gain;
@@ -105,8 +107,12 @@ public:
     const unsigned char *getVideoFrameBuffer() const override;
     void loadSettings() override;
     void saveSettings() override;
-	void setFramerate(double value, bool bUpdateConfig) override;
-	double getFramerate() const override;
+	void setFrameWidth(double value, bool bUpdateConfig) override;
+	double getFrameWidth() const override;
+	void setFrameHeight(double value, bool bUpdateConfig) override;
+	double getFrameHeight() const override;
+	void setFrameRate(double value, bool bUpdateConfig) override;
+	double getFrameRate() const override;
     void setExposure(double value, bool bUpdateConfig) override;
     double getExposure() const override;
 	void setGain(double value, bool bUpdateConfig) override;

--- a/src/psmoveservice/PSMoveTracker/PSEye/PSEyeVideoCapture.cpp
+++ b/src/psmoveservice/PSMoveTracker/PSEye/PSEyeVideoCapture.cpp
@@ -332,9 +332,17 @@ public:
 			eye->start();
 			break;
         case CV_CAP_PROP_FRAME_HEIGHT:
-            return false; //TODO: Modifying frame size probably requires resetting the camera
+			eye->stop();
+			if (!eye->setHeight((int)round(value))) return false;
+			eye->start();
+			break;
+            //return false; //TODO: Modifying frame size probably requires resetting the camera
         case CV_CAP_PROP_FRAME_WIDTH:
-            return false;
+			eye->stop();
+			if (!eye->setWidth((int)round(value))) return false;
+			eye->start();
+			break;
+            //return false;
         case CV_CAP_PROP_GAIN:
             // [0, 255] -> [0, 63] [20]
             val = (int)(value * 64.0 / 256.0);

--- a/src/psmoveservice/Server/ServerRequestHandler.cpp
+++ b/src/psmoveservice/Server/ServerRequestHandler.cpp
@@ -261,7 +261,15 @@ public:
                 response = new PSMoveProtocol::Response;
                 handle_request__get_tracker_settings(context, response);
                 break;
-			case PSMoveProtocol::Request_RequestType_SET_TRACKER_FRAMERATE:
+			case PSMoveProtocol::Request_RequestType_SET_TRACKER_FRAME_WIDTH:
+				response = new PSMoveProtocol::Response;
+				handle_request__set_tracker_frame_width(context, response);
+				break;
+			case PSMoveProtocol::Request_RequestType_SET_TRACKER_FRAME_HEIGHT:
+				response = new PSMoveProtocol::Response;
+				handle_request__set_tracker_frame_height(context, response);
+				break;
+			case PSMoveProtocol::Request_RequestType_SET_TRACKER_FRAME_RATE:
 				response = new PSMoveProtocol::Response;
 				handle_request__set_tracker_frame_rate(context, response);
 				break;
@@ -1724,7 +1732,9 @@ protected:
                     response->mutable_result_tracker_settings();
 				const int device_id = context.request->request_get_tracker_settings().device_id();
 
-				settings->set_frame_rate(static_cast<float>(tracker_view->getFramerate()));
+				settings->set_frame_width(static_cast<float>(tracker_view->getFrameWidth()));
+				settings->set_frame_height(static_cast<float>(tracker_view->getFrameHeight()));
+				settings->set_frame_rate(static_cast<float>(tracker_view->getFrameRate()));
                 settings->set_exposure(static_cast<float>(tracker_view->getExposure()));
                 settings->set_gain(static_cast<float>(tracker_view->getGain()));
                 tracker_view->gatherTrackerOptions(settings);
@@ -1758,25 +1768,25 @@ protected:
         }
     }
 
-	void handle_request__set_tracker_frame_rate(const RequestContext &context,
+	void handle_request__set_tracker_frame_width(const RequestContext &context,
 		PSMoveProtocol::Response *response)
 	{
-		const int tracker_id = context.request->request_set_tracker_frame_rate().tracker_id();
+		const int tracker_id = context.request->request_set_tracker_frame_width().tracker_id();
 
-		response->set_type(PSMoveProtocol::Response_ResponseType_TRACKER_FRAMERATE_UPDATED);
+		response->set_type(PSMoveProtocol::Response_ResponseType_TRACKER_FRAME_WIDTH_UPDATED);
 
 		if (ServerUtility::is_index_valid(tracker_id, m_device_manager.getTrackerViewMaxCount()))
 		{
 			ServerTrackerViewPtr tracker_view = m_device_manager.getTrackerViewPtr(tracker_id);
 			if (tracker_view->getIsOpen())
 			{
-				const bool bSaveSetting = context.request->request_set_tracker_frame_rate().save_setting();
-				const float desired_framerate = context.request->request_set_tracker_frame_rate().value();
-				PSMoveProtocol::Response_ResultSetTrackerFramerate* result_frame_rate =
-					response->mutable_result_set_tracker_frame_rate();
+				const bool bSaveSetting = context.request->request_set_tracker_frame_width().save_setting();
+				const float desired_frame_width = context.request->request_set_tracker_frame_width().value();
+				PSMoveProtocol::Response_ResultSetTrackerFrameWidth* result_frame_width =
+					response->mutable_result_set_tracker_frame_width();
 
-				// Set the desired framerate on the tracker
-				tracker_view->setFramerate(desired_framerate, bSaveSetting);
+				// Set the desired frame width on the tracker
+				tracker_view->setFrameWidth(desired_frame_width, bSaveSetting);
 
 				// Only save the setting if requested
 				if (bSaveSetting)
@@ -1788,8 +1798,100 @@ protected:
 					context.connection_state->active_tracker_stream_info[tracker_id].has_temp_settings_override = true;
 				}
 
-				// Return back the actual framerate that got set
-				result_frame_rate->set_new_frame_rate(static_cast<float>(tracker_view->getFramerate()));
+				// Return back the actual frame width that got set
+				result_frame_width->set_new_frame_width(static_cast<float>(tracker_view->getFrameWidth()));
+
+				response->set_result_code(PSMoveProtocol::Response_ResultCode_RESULT_OK);
+			}
+			else
+			{
+				response->set_result_code(PSMoveProtocol::Response_ResultCode_RESULT_ERROR);
+			}
+		}
+		else
+		{
+			response->set_result_code(PSMoveProtocol::Response_ResultCode_RESULT_ERROR);
+		}
+	}
+
+	void handle_request__set_tracker_frame_height(const RequestContext &context,
+		PSMoveProtocol::Response *response)
+	{
+		const int tracker_id = context.request->request_set_tracker_frame_height().tracker_id();
+
+		response->set_type(PSMoveProtocol::Response_ResponseType_TRACKER_FRAME_HEIGHT_UPDATED);
+
+		if (ServerUtility::is_index_valid(tracker_id, m_device_manager.getTrackerViewMaxCount()))
+		{
+			ServerTrackerViewPtr tracker_view = m_device_manager.getTrackerViewPtr(tracker_id);
+			if (tracker_view->getIsOpen())
+			{
+				const bool bSaveSetting = context.request->request_set_tracker_frame_height().save_setting();
+				const float desired_frame_height = context.request->request_set_tracker_frame_height().value();
+				PSMoveProtocol::Response_ResultSetTrackerFrameHeight* result_frame_height =
+					response->mutable_result_set_tracker_frame_height();
+
+				// Set the desired frame height on the tracker
+				tracker_view->setFrameHeight(desired_frame_height, bSaveSetting);
+
+				// Only save the setting if requested
+				if (bSaveSetting)
+				{
+					tracker_view->saveSettings();
+				}
+				else
+				{
+					context.connection_state->active_tracker_stream_info[tracker_id].has_temp_settings_override = true;
+				}
+
+				// Return back the actual frame height that got set
+				result_frame_height->set_new_frame_height(static_cast<float>(tracker_view->getFrameHeight()));
+
+				response->set_result_code(PSMoveProtocol::Response_ResultCode_RESULT_OK);
+			}
+			else
+			{
+				response->set_result_code(PSMoveProtocol::Response_ResultCode_RESULT_ERROR);
+			}
+		}
+		else
+		{
+			response->set_result_code(PSMoveProtocol::Response_ResultCode_RESULT_ERROR);
+		}
+	}
+
+	void handle_request__set_tracker_frame_rate(const RequestContext &context,
+		PSMoveProtocol::Response *response)
+	{
+		const int tracker_id = context.request->request_set_tracker_frame_rate().tracker_id();
+
+		response->set_type(PSMoveProtocol::Response_ResponseType_TRACKER_FRAME_RATE_UPDATED);
+
+		if (ServerUtility::is_index_valid(tracker_id, m_device_manager.getTrackerViewMaxCount()))
+		{
+			ServerTrackerViewPtr tracker_view = m_device_manager.getTrackerViewPtr(tracker_id);
+			if (tracker_view->getIsOpen())
+			{
+				const bool bSaveSetting = context.request->request_set_tracker_frame_rate().save_setting();
+				const float desired_frame_rate = context.request->request_set_tracker_frame_rate().value();
+				PSMoveProtocol::Response_ResultSetTrackerFrameRate* result_frame_rate =
+					response->mutable_result_set_tracker_frame_rate();
+
+				// Set the desired frame rate on the tracker
+				tracker_view->setFrameRate(desired_frame_rate, bSaveSetting);
+
+				// Only save the setting if requested
+				if (bSaveSetting)
+				{
+					tracker_view->saveSettings();
+				}
+				else
+				{
+					context.connection_state->active_tracker_stream_info[tracker_id].has_temp_settings_override = true;
+				}
+
+				// Return back the actual frame rate that got set
+				result_frame_rate->set_new_frame_rate(static_cast<float>(tracker_view->getFrameRate()));
 
 				response->set_result_code(PSMoveProtocol::Response_ResultCode_RESULT_OK);
 			}
@@ -2123,7 +2225,9 @@ protected:
                 TrackerProfile trackerProfile;
 
                 trackerProfile.clear();
-				trackerProfile.frame_rate = static_cast<float>(tracker_view->getFramerate());
+				trackerProfile.frame_width = static_cast<float>(tracker_view->getFrameWidth());
+				//trackerProfile.frame_height = static_cast<float>(tracker_view->getFrameHeight());
+				trackerProfile.frame_rate = static_cast<float>(tracker_view->getFrameRate());
                 trackerProfile.exposure= static_cast<float>(tracker_view->getExposure());
                 trackerProfile.gain = static_cast<float>(tracker_view->getGain());
 
@@ -2170,7 +2274,9 @@ protected:
                     m_device_manager.m_tracker_manager->getDefaultTrackerProfile();
     
                 // Apply the profile to the tracker
-				tracker_view->setFramerate(trackerProfile->frame_rate, true);
+				tracker_view->setFrameWidth(trackerProfile->frame_width, true);
+				//tracker_view->setFrameHeight(trackerProfile->frame_height, true);
+				tracker_view->setFrameRate(trackerProfile->frame_rate, true);
                 tracker_view->setExposure(trackerProfile->exposure, true);
                 tracker_view->setGain(trackerProfile->gain, true);
                 for (int preset_index = 0; preset_index < eCommonTrackingColorID::MAX_TRACKING_COLOR_TYPES; ++preset_index)
@@ -2186,7 +2292,9 @@ protected:
                     PSMoveProtocol::Response_ResultTrackerSettings* settings =
                         response->mutable_result_tracker_settings();
 
-					settings->set_frame_rate(static_cast<float>(tracker_view->getFramerate()));
+					settings->set_frame_width(static_cast<float>(tracker_view->getFrameWidth()));
+					settings->set_frame_height(static_cast<float>(tracker_view->getFrameHeight()));
+					settings->set_frame_rate(static_cast<float>(tracker_view->getFrameRate()));
                     settings->set_exposure(static_cast<float>(tracker_view->getExposure()));
                     settings->set_gain(static_cast<float>(tracker_view->getGain()));
                     tracker_view->gatherTrackerOptions(settings);

--- a/src/tests/test_camera_parallel.cpp
+++ b/src/tests/test_camera_parallel.cpp
@@ -28,11 +28,11 @@ inline void parallel_for_each(It a, It b, F&& f)
 }
 #endif
 
-const std::vector<int> known_keys = { 113, 97, 119, 115, 101, 100, 114, 102, 116, 103, 121, 104 };
-// q, a, w, s, e, d, r, f, t, g, y, h
+const std::vector<int> known_keys = { 113, 97, 119, 115, 101, 100, 114, 102, 116, 103, 121, 104, 117, 106 };
+// q, a, w, s, e, d, r, f, t, g, y, h, u, j
 
-const std::vector<int> known_keys_check = { 32, 122, 120, 99, 118, 98, 110 };
-// SPACEBAR, z, x, c, v, b, n
+const std::vector<int> known_keys_check = { 32, 122, 120, 99, 118, 98, 110, 109 };
+// SPACEBAR, z, x, c, v, b, n, m
 
 struct camera_state
 {
@@ -47,6 +47,18 @@ int main(int, char**)
 {
     std::vector<camera_state> camera_states;
 	int frame_rate_init = 40;
+	int frame_width_init = 640;
+
+	bool ask_for_input = true;
+	char yesno = 'y';
+	std::cout << "Enter individual settings? [y/n]: ";
+	std::cin >> yesno;
+	if (yesno == 'n') ask_for_input = false;
+	else if (yesno == 'q')
+	{
+		ask_for_input = false;
+		frame_width_init = 320;
+	}
 
     // Open all available cameras (up to 30 max)
 	for (int camera_index = 0; camera_index < 30; ++camera_index)
@@ -57,13 +69,20 @@ int main(int, char**)
         {
             std::string identifier = camera->getUniqueIndentifier();
 
-			std::cout << "Enter initial frame rate for  camera " << identifier << ": " ;
-			std::cin >> frame_rate_init;
-			
-			if (camera->get(CV_CAP_PROP_FPS) != frame_rate_init)
+			if (ask_for_input) 
 			{
-				camera->set(CV_CAP_PROP_FPS, frame_rate_init);
+				std::cout << "Enter initial frame width for camera " << identifier << ": ";
+				std::cin >> frame_width_init;
+
+				std::cout << "Enter initial frame rate for camera " << identifier << ": ";
+				std::cin >> frame_rate_init;
 			}
+
+			if (camera->get(CV_CAP_PROP_FRAME_WIDTH) != frame_width_init)
+				camera->set(CV_CAP_PROP_FRAME_WIDTH, frame_width_init);
+
+			if (camera->get(CV_CAP_PROP_FPS) != frame_rate_init)
+				camera->set(CV_CAP_PROP_FPS, frame_rate_init);
 
 			auto last_ticks = std::chrono::high_resolution_clock::now();
 			int last_frames = 0;
@@ -82,13 +101,17 @@ int main(int, char**)
 		<< " r | f |   v   | Hue \n"
 		<< " t | g |   b   | Sharpness \n"
 		<< " y | h |   n   | Fame Rate \n"
+		<< " u | j |   m   | Fame Width \n"
 		<< "Check the calculated frame rate with the space bar and close cameras with escape \n"
 		;
+
+	bool closeAll = false;
+
     // Create a window for each opened camera
 	parallel_for_each(
         camera_states.begin(), 
         camera_states.end(),
-		[&camera_states](camera_state &state) {
+		[&camera_states, &closeAll](camera_state &state) {
             cv::namedWindow(state.identifier.c_str(), 1);
 
     //bool bKeepRunning = camera_states.size() > 0;
@@ -105,12 +128,16 @@ int main(int, char**)
 			state.last_frames++;
         }
 
-        int wk = cv::waitKey(10);
+        int wk = cv::waitKey(1);
 
-        if (wk == 27)  // Escape
+        if (wk == 27 || closeAll)  // Escape
         {
             bKeepRunning = false;
         }
+		else if (wk == 7536640) // F4
+		{
+			closeAll = true;
+		}
         else if (std::find(known_keys.begin(), known_keys.end(), wk) != known_keys.end())
         {
             int cap_prop = CV_CAP_PROP_EXPOSURE;
@@ -171,24 +198,67 @@ int main(int, char**)
 				val_diff = (wk == 121) ? 10 : -10;
 			}
 
+			// u/j for +/- frame width
+			// For CL_Eye, don't know
+			if ((wk == 117) || (wk == 106))
+			{
+				cap_prop = CV_CAP_PROP_FRAME_WIDTH;
+				prop_str = "CV_CAP_PROP_FRAME_WIDTH";
+				val_diff = (wk == 117) ? 1 : -1;
+			}
+
             double val = state.camera->get(cap_prop);
             std::cout << state.identifier << ": Value of " << prop_str << " was " << val << std::endl;
 
 			switch (cap_prop)
 			{
+			case CV_CAP_PROP_FRAME_WIDTH:
+				if (val == 320) { if (val_diff > 0) val_diff = 320; else val_diff = 0; }
+				else if (val == 640) { if (val_diff > 0) val_diff = 0; else val_diff = -320; }
+				break;
 			case CV_CAP_PROP_FPS:
-				if (val == 2) { if (val_diff > 0) val_diff = 1; else val_diff = 0; }
-				else if (val == 3) { if (val_diff > 0) val_diff = 2; else val_diff = -1; }
-				else if (val == 5) { if (val_diff > 0) val_diff = 3; else val_diff = -2; }
-				else if (val == 8) { if (val_diff > 0) val_diff = 2; else val_diff = -3; }
-				else if (val == 10) { if (val_diff > 0) val_diff = 5; else val_diff = -2; }
-				else if (val == 15) { if (val_diff > 0) val_diff = 5; else val_diff = -5; }
-				else if (val == 20) { if (val_diff > 0) val_diff = 5; else val_diff = -5; }
-				else if (val == 25) { if (val_diff > 0) val_diff = 5; else val_diff = -5; }
-				else if (val == 30) { if (val_diff < 0) { val_diff = -5; } }
-				else if (val == 60) { if (val_diff > 0) { val_diff = 15; } }
-				else if (val == 75) { if (val_diff > 0) val_diff = 8; else val_diff = -15; }
-				else if (val == 83) { if (val_diff < 0) val_diff = -8; }
+				int frame_width = state.camera->get(CV_CAP_PROP_FRAME_WIDTH);
+				if (frame_width == 640)
+				{
+					if (val == 2) { if (val_diff > 0) val_diff = 1; else val_diff = 0; }
+					else if (val == 3) { if (val_diff > 0) val_diff = 2; else val_diff = -1; }
+					else if (val == 5) { if (val_diff > 0) val_diff = 3; else val_diff = -2; }
+					else if (val == 8) { if (val_diff > 0) val_diff = 2; else val_diff = -3; }
+					else if (val == 10) { if (val_diff > 0) val_diff = 5; else val_diff = -2; }
+					else if (val == 15) { if (val_diff > 0) val_diff = 5; else val_diff = -5; }
+					else if (val == 20) { if (val_diff > 0) val_diff = 5; else val_diff = -5; }
+					else if (val == 25) { if (val_diff > 0) val_diff = 5; else val_diff = -5; }
+					else if (val == 30) { if (val_diff < 0) { val_diff = -5; } }
+					else if (val == 60) { if (val_diff > 0) { val_diff = 15; } }
+					else if (val == 75) { if (val_diff > 0) val_diff = 8; else val_diff = -15; }
+					else if (val == 83) { if (val_diff < 0) val_diff = -8; }
+				}
+				else
+				{
+					if (val == 2) { if (val_diff > 0) val_diff = 1; else val_diff = 0; }
+					else if (val == 3) { if (val_diff > 0) val_diff = 2; else val_diff = -1; }
+					else if (val == 5) { if (val_diff > 0) val_diff = 2; else val_diff = -2; }
+					else if (val == 7) { if (val_diff > 0) val_diff = 3; else val_diff = -2; }
+					else if (val == 10) { if (val_diff > 0) val_diff = 2; else val_diff = -3; }
+					else if (val == 12) { if (val_diff > 0) val_diff = 3; else val_diff = -2; }
+					else if (val == 15) { if (val_diff > 0) val_diff = 2; else val_diff = -3; }
+					else if (val == 17) { if (val_diff > 0) val_diff = 13; else val_diff = -2; }
+					else if (val == 30) { if (val_diff > 0) val_diff = 7; else val_diff = -13; }
+					else if (val == 37) { if (val_diff > 0) val_diff = 3; else val_diff = -7; }
+					else if (val == 40) { if (val_diff > 0) val_diff = 10; else val_diff = -3; }
+					else if (val == 50) { if (val_diff > 0) val_diff = 10; else val_diff = -10; }
+					else if (val == 60) { if (val_diff > 0) val_diff = 15; else val_diff = -10; }
+					else if (val == 75) { if (val_diff > 0) val_diff = 15; else val_diff = -15; }
+					else if (val == 90) { if (val_diff > 0) val_diff = 10; else val_diff = -15; }
+					else if (val == 100) { if (val_diff > 0) val_diff = 25; else val_diff = -10; }
+					else if (val == 125) { if (val_diff > 0) val_diff = 12; else val_diff = -25; }
+					else if (val == 137) { if (val_diff > 0) val_diff = 13; else val_diff = -12; }
+					else if (val == 150) { if (val_diff > 0) val_diff = 37; else val_diff = -13; }
+					else if (val == 187) { if (val_diff > 0) val_diff = 18; else val_diff = -37; }
+					else if (val == 205) { if (val_diff > 0) val_diff = 85; else val_diff = -18; }
+					else if (val == 290) { if (val_diff > 0) val_diff = 0; else val_diff = -85; }
+				}
+				break;
 			}
 
 			val += val_diff;
@@ -243,6 +313,13 @@ int main(int, char**)
 			{
 				cap_prop = CV_CAP_PROP_SHARPNESS;
 				prop_str = "CV_CAP_PROP_SHARPNESS";
+			}
+
+			// M	 to check frame width
+			if (wk == 109)
+			{
+				cap_prop = CV_CAP_PROP_FRAME_WIDTH;
+				prop_str = "CV_CAP_PROP_FRAME_WIDTH";
 			}
 
 			double val = state.camera->get(cap_prop);


### PR DESCRIPTION
Added control over the PSEye frame width and height. Since they are
linked only the width is specified in the configuration files but both
are available to be changed. They have been implemented similar to the
frame rate. The frame rate calls have been slightly changed so that they
match the frame width and height (ie. Framerate has been renamed FrameRate).

When changing the frame resolution the buffer is closed and reopened by
ServerTrackerView so that it has the correct size. This causes the video
feed in Color calibration to freeze so it is automatically exited and
reopened.

The QVGA resolution may be useful for the position triangulation method
if more than four cameras are used.

This currently uses my fork of PS3EYEDriver but I've already made a PR for it (https://github.com/inspirit/PS3EYEDriver/pull/42).