### PR TITLE
Added an optinal alignment marker to the colour calibration window

### DIFF
--- a/src/psmoveconfigtool/AppStage_ColorCalibration.h
+++ b/src/psmoveconfigtool/AppStage_ColorCalibration.h
@@ -200,6 +200,8 @@ private:
 
 	// Setting Windows visability
 	bool m_bShowWindows;
+	bool m_bShowAlignment;
+	bool m_bShowAlignmentColor;
 };
 
 #endif // APP_STAGE_COLOR_CALIBRATION_H


### PR DESCRIPTION
To help in aligning the trackers, an optional alignment marker has
been added to the Calibrate Controller Tracking Colours window. This
marker can be accessed by pressing the X key and has two modes (cycled
with the X key). The first mode uses a black cross to mark the absolute
center. The second mode uses the color oposite to the current orb color.