### PR TITLE
Integrate the alignment marker into the auto colour calibration

### DIFF
--- a/src/psmoveconfigtool/AppStage_ColorCalibration.h
+++ b/src/psmoveconfigtool/AppStage_ColorCalibration.h
@@ -197,11 +197,13 @@ private:
 	bool m_bAutoChangeController;
 	bool m_bAutoChangeColor;
 	bool m_bAutoChangeTracker;
+	bool m_bAutoCalibrate;
 
 	// Setting Windows visability
 	bool m_bShowWindows;
 	bool m_bShowAlignment;
 	bool m_bShowAlignmentColor;
+	float m_AlignmentOffset;
 };
 
 #endif // APP_STAGE_COLOR_CALIBRATION_H

--- a/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.h
+++ b/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.h
@@ -147,6 +147,10 @@ protected:
     bool m_bSkipCalibration;
     int m_ShowTrackerVideoId;
 	int m_overrideControllerId;
+
+	// Alignment Marker visability
+	bool m_bShowAlignment;
+	float m_AlignmentOffset;
 };
 
 #endif // APP_STAGE_COMPUTE_TRACKER_POSES_H


### PR DESCRIPTION
* Since the position of the orb is the same for all trackers when using
the alignment marker, this position can be used instead of the mouse
position. This also alows the calibration to continue uninterupted when
the tracker is changed. Auto controller switching however is then disabled.

* The surface used to place the controller on may not be vertically
centered (such as the floor) so the marker can now be moved up and down
using the W and S keys and recentered with the Z key.

* A similar marker has also been added to the verification step of the
tracker pose calibration but only has a black cross and it's vertical
position isn't synced with the other marker.