### PR TITLE
Fix for #411 and others

### DIFF
--- a/src/psmoveclient/PSMoveClient_CAPI.cpp
+++ b/src/psmoveclient/PSMoveClient_CAPI.cpp
@@ -731,7 +731,9 @@ PSMResult PSM_GetIsControllerStable(PSMControllerID controller_id, bool *out_is_
 
 				*out_is_stable =
 					is_nearly_equal(1.f, acceleration_magnitude, 0.1f) &&
-					PSM_Vector3fDot(&k_identity_gravity_calibration_direction, &acceleration_direction) >= k_cosine_10_degrees;
+					(PSM_Vector3fDot(&k_identity_gravity_calibration_direction, &acceleration_direction)
+						/ (PSM_Vector3fLength(&k_identity_gravity_calibration_direction) 
+							* PSM_Vector3fLength(&acceleration_direction))) >= k_cosine_10_degrees;
 
 				result= PSMResult_Success;
             } break;

--- a/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.cpp
+++ b/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.cpp
@@ -562,7 +562,9 @@ void AppStage_ComputeTrackerPoses::renderUI()
 					go_previous_tracker();
 				}
 				ImGui::SameLine();
-				ImGui::Text("Tracker ID: #%d", m_renderTrackerIter->second.trackerView->tracker_info.tracker_id);
+				int TrackerID = m_renderTrackerIter->second.trackerView->tracker_info.tracker_id;
+				ImGui::Text("Tracker ID: #%d", TrackerID);
+				m_app->getAppStage<AppStage_TrackerSettings>()->set_selectedTrackerIndex(TrackerID);
 				ImGui::SameLine();
 				if (ImGui::Button(">##Next Tracker"))
 				{
@@ -1236,15 +1238,21 @@ bool AppStage_ComputeTrackerPoses::does_tracker_see_any_controller(const PSMTrac
 		if (controllerView->ControllerType == PSMControllerType::PSMController_Move &&
 			controllerView->ControllerState.PSMoveState.bIsCurrentlyTracking)
 		{
-			screenSample= controllerView->ControllerState.PSMoveState.RawTrackerData.ScreenLocations[tracker_id];
-			bTrackerSeesAnyController = true;
+			for (int id = 0; id < controllerView->ControllerState.PSMoveState.RawTrackerData.ValidTrackerLocations; ++id)
+			{
+				if (controllerView->ControllerState.PSMoveState.RawTrackerData.TrackerIDs[id] == tracker_id)
+					bTrackerSeesAnyController = true;
+			}
 			break;
 		}
 		else if (controllerView->ControllerType == PSMControllerType::PSMController_DualShock4 &&
 				 controllerView->ControllerState.PSDS4State.bIsCurrentlyTracking)
 		{
-			screenSample= controllerView->ControllerState.PSDS4State.RawTrackerData.ScreenLocations[tracker_id];
-			bTrackerSeesAnyController = true;
+			for (int id = 0; id < controllerView->ControllerState.PSMoveState.RawTrackerData.ValidTrackerLocations; ++id)
+			{
+				if (controllerView->ControllerState.PSMoveState.RawTrackerData.TrackerIDs[id] == tracker_id)
+					bTrackerSeesAnyController = true;
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
* For #411 added a check to find if the current tracker is in the
  controller's tracker list.

* The controller stability check was not working. The angle calculation
  was incomplete but is now fixed.

* Switching between test tracking and colour calibration did not always
  remember which tracker was currently selected but it now does.