### PR TITLE
Fix for #255

### DIFF
--- a/src/psmoveconfigtool/AppStage_TestRumble.cpp
+++ b/src/psmoveconfigtool/AppStage_TestRumble.cpp
@@ -26,6 +26,7 @@ AppStage_TestRumble::AppStage_TestRumble(App *app)
     : AppStage(app)
     , m_menuState(AppStage_TestRumble::inactive)
     , m_controllerView(nullptr)
+	, m_bExitMain(false)
 {
 }
 
@@ -172,16 +173,28 @@ void AppStage_TestRumble::renderUI()
 
             if (ImGui::Button("Controller Settings"))
             {
-                request_exit_to_app_stage(AppStage_ControllerSettings::APP_STAGE_NAME);
+				set_rumble_amounts(0.f, 0.f);
+				m_bExitMain = false;
+				m_menuState = eMenuState::stop;
+
             }
             ImGui::SameLine();
             if (ImGui::Button("Main Menu"))
             {
-                request_exit_to_app_stage(AppStage_MainMenu::APP_STAGE_NAME);
+				set_rumble_amounts(0.f, 0.f);
+				m_bExitMain = true;
+				m_menuState = eMenuState::stop;
             }
 
             ImGui::End();
         } break;
+	case eMenuState::stop:
+	{
+		if (m_bExitMain)
+			request_exit_to_app_stage(AppStage_MainMenu::APP_STAGE_NAME);
+		else
+			request_exit_to_app_stage(AppStage_ControllerSettings::APP_STAGE_NAME);
+	} break;
 
     default:
         assert(0 && "unreachable");

--- a/src/psmoveconfigtool/AppStage_TestRumble.h
+++ b/src/psmoveconfigtool/AppStage_TestRumble.h
@@ -42,11 +42,14 @@ private:
         waitingForStreamStartResponse,
         failedStreamStart,
         idle,
+		stop,
     };
 
     eMenuState m_menuState;
 
     PSMController *m_controllerView;
+
+	bool m_bExitMain;
 };
 
 #endif // APP_STAGE_TEST_RUMBLE_H


### PR DESCRIPTION
The rumble now turns off if it was on when leaving the test rumble menu.