### PR TITLE
Added VirtualController to the list of device types in the DeviceTypeManager

### DIFF
--- a/src/psmoveservice/Device/Interface/DeviceInterface.h
+++ b/src/psmoveservice/Device/Interface/DeviceInterface.h
@@ -251,6 +251,9 @@ struct CommonDeviceState
         case VirtualHMD:
             result = "VirtualHMD";
             break;
+        case VirtualController:
+            result = "VirtualController";
+            break;
         default:
             result = "UNKNOWN";
         }


### PR DESCRIPTION
VirtualController was previously showing as "UNKNOWN".