### PR TITLE
Adding gamepad assignment to VirtualControllers

### DIFF
--- a/src/psmoveclient/ClientConstants.h
+++ b/src/psmoveclient/ClientConstants.h
@@ -26,6 +26,12 @@
 // The max length of the service version string
 #define PSMOVESERVICE_MAX_VERSION_STRING_LEN 32
 
+// The max number of axes allowed on a virtual controller
+#define PSM_MAX_VIRTUAL_CONTROLLER_AXES  32
+
+// The max number of buttons allowed on a virtual controller
+#define PSM_MAX_VIRTUAL_CONTROLLER_BUTTONS  32
+
 // Defines a standard _PAUSE function
 #if __cplusplus >= 199711L  // if C++11
     #include <thread>

--- a/src/psmoveclient/PSMoveClient.cpp
+++ b/src/psmoveclient/PSMoveClient.cpp
@@ -1682,7 +1682,26 @@ static void applyVirtualControllerDataFrame(
     virtual_controller->Pose.Position.x= virtual_controller_packet.position_cm().x();
     virtual_controller->Pose.Position.y= virtual_controller_packet.position_cm().y();
     virtual_controller->Pose.Position.z= virtual_controller_packet.position_cm().z();
-            
+
+    virtual_controller->vendorID= virtual_controller_packet.vendorid();
+    virtual_controller->productID= virtual_controller_packet.productid();
+
+    virtual_controller->numAxes = virtual_controller_packet.axisstates_size();
+    virtual_controller->numButtons = virtual_controller_packet.numbuttons();
+
+    unsigned int button_bitmask = controller_packet.button_down_bitmask();
+    memset(virtual_controller->buttonStates, PSMButtonState_UP, sizeof(virtual_controller->buttonStates));
+    for (int button_index = 0; button_index < virtual_controller->numButtons; ++button_index)
+    {
+    	applyPSMButtonState(virtual_controller->buttonStates[button_index], button_bitmask, button_index);
+    }
+
+    memset(virtual_controller->axisStates, 0x7f, sizeof(virtual_controller->axisStates));
+    for (int axis_index = 0; axis_index < virtual_controller->numAxes; ++axis_index)
+    {
+        virtual_controller->axisStates[axis_index]= virtual_controller_packet.axisstates(axis_index);
+    }
+
     if (virtual_controller_packet.has_physics_data())
     {
         const auto &raw_physics_data = virtual_controller_packet.physics_data();

--- a/src/psmoveclient/PSMoveClient_CAPI.h
+++ b/src/psmoveclient/PSMoveClient_CAPI.h
@@ -272,8 +272,8 @@ typedef struct
     PSMButtonState               DPadDownButton;
     PSMButtonState               DPadLeftButton;
     unsigned char                TriggerValue;
-    float                        Stick_XAxis;
-    float                        Stick_YAxis;
+    unsigned char                Stick_XAxis;
+    unsigned char                Stick_YAxis;
 } PSMPSNavi;
 
 /// DualShock4 raw IMU sensor data
@@ -362,6 +362,15 @@ typedef struct
     bool                         bIsPositionValid;
     
     char                         DevicePath[256];
+
+    int                          vendorID;
+    int                          productID;
+    
+    int                          numAxes;
+    int                          numButtons;
+    
+    unsigned char                axisStates[PSM_MAX_VIRTUAL_CONTROLLER_AXES];
+    PSMButtonState               buttonStates[PSM_MAX_VIRTUAL_CONTROLLER_BUTTONS];
     
     PSMTrackingColorType         TrackingColorType;
     PSMPosef                     Pose;

--- a/src/psmoveconfigtool/AppStage_ControllerSettings.h
+++ b/src/psmoveconfigtool/AppStage_ControllerSettings.h
@@ -8,6 +8,8 @@
 #include <vector>
 #include <string>
 
+#define MAX_GAMEPAD_LABELS  16+1
+
 //-- definitions -----
 class AppStage_ControllerSettings : public AppStage
 {
@@ -34,6 +36,7 @@ public:
 		int GyroGainIndex;
 		std::string GyroGainSetting;
 		float PredictionTime;
+        int GamepadIndex;
 
 		static bool ParentControllerComboItemGetter(void* userdata, int index, const char** out_string)
 		{
@@ -48,6 +51,22 @@ public:
 			else
 			{
 				*out_string= "<INVALID>";
+				return false;
+			}
+		}
+
+		static bool GamepadIndexComboItemGetter(void* userdata, int index, const char** out_string)
+		{
+			const AppStage_ControllerSettings *this_ptr= reinterpret_cast<AppStage_ControllerSettings *>(userdata);            
+			
+			if (index >= 0 && index <= this_ptr->m_gamepadCount && index < MAX_GAMEPAD_LABELS)
+			{
+                *out_string= AppStage_ControllerSettings::GAMEPAD_COMBO_LABELS[index];
+				return true;
+			}
+			else
+			{
+				*out_string= "<NONE>";
 				return false;
 			}
 		}
@@ -85,6 +104,7 @@ protected:
 	void request_set_position_filter(const int controller_id, const std::string &filter_name);
 	void request_set_gyroscope_gain_setting(const int controller_id, const std::string& gain_setting);
 	void request_set_controller_prediction(const int controller_id, float prediction_time);
+    void request_set_controller_gamepad_index(const int controller_id, const int gamepad_index);
 
 	int find_controller_id_by_serial(std::string parent_controller_serial) const;
 
@@ -109,8 +129,11 @@ private:
     std::vector<ControllerInfo> m_usableControllerInfos;
     std::vector<ControllerInfo> m_awaitingPairingControllerInfos;
     std::string m_hostSerial;
+    int m_gamepadCount;
 
     int m_selectedControllerIndex;
+    
+    static const char *GAMEPAD_COMBO_LABELS[MAX_GAMEPAD_LABELS];
 };
 
 #endif // APP_STAGE_SELECT_CONTROLLER_H

--- a/src/psmoveconfigtool/psmove_config_tool.cpp
+++ b/src/psmoveconfigtool/psmove_config_tool.cpp
@@ -16,6 +16,7 @@
 #include "AppStage_PairController.h"
 #include "AppStage_ServiceSettings.h"
 #include "AppStage_TrackerSettings.h"
+#include "AppStage_TestButtons.h"
 #include "AppStage_TestTracker.h"
 #include "AppStage_TestRumble.h"
 
@@ -49,6 +50,7 @@ extern "C" int main(int argc, char *argv[])
 	app.registerAppStage<AppStage_OpticalCalibration>();
     app.registerAppStage<AppStage_PairController>();
     app.registerAppStage<AppStage_ServiceSettings>();
+    app.registerAppStage<AppStage_TestButtons>();
     app.registerAppStage<AppStage_TestRumble>();
     app.registerAppStage<AppStage_TestTracker>();
     app.registerAppStage<AppStage_TrackerSettings>();

--- a/src/psmoveprotocol/PSMoveProtocol.proto
+++ b/src/psmoveprotocol/PSMoveProtocol.proto
@@ -128,38 +128,39 @@ message Request {
         SET_POSITION_FILTER= 15;
         SET_CONTROLLER_PREDICTION_TIME= 16;
         SET_ATTACHED_CONTROLLER= 17;
+        SET_GAMEPAD_INDEX= 18;
 
-        GET_TRACKER_LIST = 18;
-        START_TRACKER_DATA_STREAM = 19;
-        STOP_TRACKER_DATA_STREAM = 20;
-        GET_TRACKER_SETTINGS = 21;
-        SET_TRACKER_EXPOSURE = 22;
-        SET_TRACKER_GAIN = 23;
-        SET_TRACKER_OPTION = 24;
-        SET_TRACKER_COLOR_PRESET = 25;
-        SET_TRACKER_POSE = 26;
-        SET_TRACKER_INTRINSICS = 27;
-        RELOAD_TRACKER_SETTINGS = 28;
-        SAVE_TRACKER_PROFILE = 29;
-        APPLY_TRACKER_PROFILE = 30;
-        SEARCH_FOR_NEW_TRACKERS = 31;
-        GET_TRACKING_SPACE_SETTINGS = 32;
+        GET_TRACKER_LIST = 19;
+        START_TRACKER_DATA_STREAM = 20;
+        STOP_TRACKER_DATA_STREAM = 21;
+        GET_TRACKER_SETTINGS = 22;
+        SET_TRACKER_EXPOSURE = 23;
+        SET_TRACKER_GAIN = 24;
+        SET_TRACKER_OPTION = 25;
+        SET_TRACKER_COLOR_PRESET = 26;
+        SET_TRACKER_POSE = 27;
+        SET_TRACKER_INTRINSICS = 28;
+        RELOAD_TRACKER_SETTINGS = 29;
+        SAVE_TRACKER_PROFILE = 30;
+        APPLY_TRACKER_PROFILE = 31;
+        SEARCH_FOR_NEW_TRACKERS = 32;
+        GET_TRACKING_SPACE_SETTINGS = 33;
 
-        GET_HMD_LIST = 33;
-        START_HMD_DATA_STREAM = 34;
-        STOP_HMD_DATA_STREAM = 35;
-        SET_HMD_LED_TRACKING_COLOR= 36;
-        SET_HMD_ACCELEROMETER_CALIBRATION= 37;
-        SET_HMD_GYROSCOPE_CALIBRATION= 38;
-        SET_HMD_PREDICTION_TIME= 39;
-        SET_HMD_ORIENTATION_FILTER= 40;
-        SET_HMD_POSITION_FILTER= 41;        
+        GET_HMD_LIST = 34;
+        START_HMD_DATA_STREAM = 35;
+        STOP_HMD_DATA_STREAM = 36;
+        SET_HMD_LED_TRACKING_COLOR= 37;
+        SET_HMD_ACCELEROMETER_CALIBRATION= 38;
+        SET_HMD_GYROSCOPE_CALIBRATION= 39;
+        SET_HMD_PREDICTION_TIME= 40;
+        SET_HMD_ORIENTATION_FILTER= 41;
+        SET_HMD_POSITION_FILTER= 42;        
 
-        GET_SERVICE_VERSION= 42;
+        GET_SERVICE_VERSION= 43;
 
-        SET_TRACKER_FRAME_RATE = 43;
-        SET_TRACKER_FRAME_WIDTH = 44;
-        SET_TRACKER_FRAME_HEIGHT = 45;
+        SET_TRACKER_FRAME_RATE = 44;
+        SET_TRACKER_FRAME_WIDTH = 45;
+        SET_TRACKER_FRAME_HEIGHT = 46;
     }
     RequestType type = 2;
 
@@ -283,26 +284,33 @@ message Request {
     }
     RequestSetControllerPredictionTime request_set_controller_prediction_time = 19;
 
-    // Parameters SET_ATTACHED_CONTROLLER
+    // Parameters for SET_ATTACHED_CONTROLLER
     message RequestSetAttachedController {
         int32 child_controller_id = 1;
         int32 parent_controller_id = 2;
     }
     RequestSetAttachedController request_set_attached_controller = 20;
-
+    
+    // Parameters for SET_GAMEPAD_INDEX
+    message RequestSetGamepadIndex {
+        int32 controller_id = 1;
+        int32 gamepad_index = 2;
+    }
+    RequestSetGamepadIndex request_set_gamepad_index = 21;
+    
     // Parameters for START_TRACKER_DATA_STREAM
     // NOTE: DeviceDataFrame packets will start streaming to client upon receiving this request
     message RequestStartTrackerDataStream {
         int32 tracker_id = 1;
     }
-    RequestStartTrackerDataStream request_start_tracker_data_stream = 21;
+    RequestStartTrackerDataStream request_start_tracker_data_stream = 22;
 
     // Parameters for STOP_TRACKER_DATA_STREAM
     // NOTE: DeviceDataFrame packets will stop streaming to client upon receiving this request
     message RequestStopTrackerDataStream {
         int32 tracker_id = 1;
     }
-    RequestStopTrackerDataStream request_stop_tracker_data_stream = 22;
+    RequestStopTrackerDataStream request_stop_tracker_data_stream = 23;
 
     // Parameters for GET_TRACKER_SETTINGS
     message RequestGetTrackerSettings {
@@ -315,7 +323,7 @@ message Request {
         }
         DeviceCategory device_category= 3;
     }
-    RequestGetTrackerSettings request_get_tracker_settings = 23;
+    RequestGetTrackerSettings request_get_tracker_settings = 24;
 
     // Parameters for SET_TRACKER_EXPOSURE
     message RequestSetTrackerExposure {
@@ -323,7 +331,7 @@ message Request {
         float value = 2;
         bool save_setting= 3;
     }
-    RequestSetTrackerExposure request_set_tracker_exposure = 24;
+    RequestSetTrackerExposure request_set_tracker_exposure = 25;
 
     // Parameters for SET_TRACKER_GAIN
     message RequestSetTrackerGain {
@@ -331,7 +339,7 @@ message Request {
         float value = 2;
         bool save_setting= 3;
     }
-    RequestSetTrackerGain request_set_tracker_gain = 25;
+    RequestSetTrackerGain request_set_tracker_gain = 26;
 
     // Parameters for SET_TRACKER_OPTION
     message RequestSetTrackerOption {
@@ -339,7 +347,7 @@ message Request {
         string option_name = 2;
         int32 option_index = 3;
     }
-    RequestSetTrackerOption request_set_tracker_option = 26;
+    RequestSetTrackerOption request_set_tracker_option = 27;
 
     // Parameters for SET_TRACKER_COLOR_PRESET
     message RequestSetTrackerColorPreset {
@@ -354,7 +362,7 @@ message Request {
 
         TrackingColorPreset color_preset = 4;
     }
-    RequestSetTrackerColorPreset request_set_tracker_color_preset = 27;
+    RequestSetTrackerColorPreset request_set_tracker_color_preset = 28;
 
     // Parameters for SET_TRACKER_INTRINSICS
     message RequestSetTrackerIntrinsics {
@@ -367,34 +375,34 @@ message Request {
         float tracker_p1= 7;
         float tracker_p2= 8;
     }
-    RequestSetTrackerIntrinsics request_set_tracker_intrinsics = 28;
+    RequestSetTrackerIntrinsics request_set_tracker_intrinsics = 29;
 
     // Parameters for SET_TRACKER_POSE
     message RequestSetTrackerPose {
         int32 tracker_id = 1;
         Pose pose = 2;
     }
-    RequestSetTrackerPose request_set_tracker_pose = 29;
+    RequestSetTrackerPose request_set_tracker_pose = 30;
 
     // Parameters for RELOAD_TRACKER_SETTINGS
     message RequestReloadTrackerSettings {
       int32 tracker_id = 1;
     }
-    RequestReloadTrackerSettings request_reload_tracker_settings = 30;
+    RequestReloadTrackerSettings request_reload_tracker_settings = 31;
 
     // Parameters for SAVE_TRACKER_PROFILE
     message RequestSaveTrackerProfile {
         int32 tracker_id = 1;
         int32 controller_id = 2;
     }
-    RequestSaveTrackerProfile request_save_tracker_profile = 31;
+    RequestSaveTrackerProfile request_save_tracker_profile = 32;
 
     // Parameters for APPLY_TRACKER_PROFILE
     message RequestApplyTrackerProfile {
         int32 tracker_id = 1;
         int32 controller_id = 2;
     }
-    RequestApplyTrackerProfile request_apply_tracker_profile = 32;
+    RequestApplyTrackerProfile request_apply_tracker_profile = 33;
 
     // No Parameters for SEARCH_FOR_NEW_TRACKERS
 
@@ -409,21 +417,21 @@ message Request {
         bool include_raw_tracker_data= 6;
         bool disable_roi= 7;
     }
-    RequestStartHmdDataStream request_start_hmd_data_stream = 33;
+    RequestStartHmdDataStream request_start_hmd_data_stream = 34;
 
     // Parameters for STOP_HMD_DATA_STREAM
     // NOTE: DeviceDataFrame packets will stop streaming to client upon receiving this request
     message RequestStopHmdDataStream {
         int32 hmd_id = 1;
     }
-    RequestStopHmdDataStream request_stop_hmd_data_stream = 34;
+    RequestStopHmdDataStream request_stop_hmd_data_stream = 35;
 
     // Parameters for SET_HMD_LED_TRACKING_COLOR
     message RequestSetHmdLEDTrackingColor {
         int32 hmd_id = 1;
         TrackingColorType color_type = 2;
     }
-    RequestSetHmdLEDTrackingColor set_hmd_led_tracking_color_request = 35;    
+    RequestSetHmdLEDTrackingColor set_hmd_led_tracking_color_request = 36;    
     
     // Parameters for SET_HMD_ACCELEROMETER_CALIBRATION
     message RequestSetHMDAccelerometerCalibration {
@@ -431,7 +439,7 @@ message Request {
         FloatVector raw_average_gravity= 2;
         float raw_variance= 3;
     }
-    RequestSetHMDAccelerometerCalibration set_hmd_accelerometer_calibration_request = 36;
+    RequestSetHMDAccelerometerCalibration set_hmd_accelerometer_calibration_request = 37;
 
     // Parameters for SET_HMD_GYROSCOPE_CALIBRATION
     message RequestSetHMDGyroscopeCalibration {
@@ -440,7 +448,7 @@ message Request {
         float raw_variance= 3;
         float raw_drift= 4;
     }
-    RequestSetHMDGyroscopeCalibration set_hmd_gyroscope_calibration_request = 37;
+    RequestSetHMDGyroscopeCalibration set_hmd_gyroscope_calibration_request = 38;
 
     // No parameters for GET_TRACKING_SPACE_SETTINGS
 
@@ -449,21 +457,21 @@ message Request {
         int32 hmd_id = 1;
         string orientation_filter = 2;
     }
-    RequestSetHMDOrientationFilter request_set_hmd_orientation_filter = 38;
+    RequestSetHMDOrientationFilter request_set_hmd_orientation_filter = 39;
 
     // Parameters for SET_HMD_POSITION_FILTER
     message RequestSetHMDPositionFilter {
         int32 hmd_id = 1;
         string position_filter = 2;
     }
-    RequestSetHMDPositionFilter request_set_hmd_position_filter = 39;
+    RequestSetHMDPositionFilter request_set_hmd_position_filter = 40;
     
     // Parameters for SET_HMD_PREDICTION_TIME
     message RequestSetHMDPredictionTime {
         int32 hmd_id = 1;
         float prediction_time = 2;
     }
-    RequestSetHMDPredictionTime request_set_hmd_prediction_time = 40;
+    RequestSetHMDPredictionTime request_set_hmd_prediction_time = 41;
 
     // Parameters for SET_TRACKER_FRAME_RATE
     message RequestSetTrackerFrameRate {
@@ -471,7 +479,7 @@ message Request {
         float value = 2;
         bool save_setting= 3;
     }
-    RequestSetTrackerFrameRate request_set_tracker_frame_rate = 41;
+    RequestSetTrackerFrameRate request_set_tracker_frame_rate = 42;
 
     // Parameters for SET_TRACKER_FRAME_WIDTH
     message RequestSetTrackerFrameWidth {
@@ -479,7 +487,7 @@ message Request {
         float value = 2;
         bool save_setting= 3;
     }
-    RequestSetTrackerFrameWidth request_set_tracker_frame_width = 42;
+    RequestSetTrackerFrameWidth request_set_tracker_frame_width = 43;
 
     // Parameters for SET_TRACKER_FRAME_HEIGHT
     message RequestSetTrackerFrameHeight {
@@ -487,7 +495,7 @@ message Request {
         float value = 2;
         bool save_setting= 3;
     }
-    RequestSetTrackerFrameHeight request_set_tracker_frame_height = 43;
+    RequestSetTrackerFrameHeight request_set_tracker_frame_height = 44;
 }
 
 // Reliable (TCP) responses to requests
@@ -567,9 +575,11 @@ message Response {
             string position_filter = 13;
             string gyro_gain_setting = 14;
             float prediction_time = 15;
+            int32 gamepad_index = 16;
         }
         repeated ControllerInfo controllers = 1;
         string host_serial = 2;
+        int32 gamepad_count = 3;
     }
     ResultControllerList result_controller_list = 22;
 
@@ -926,6 +936,16 @@ message DeviceOutputDataFrame
 
             // Tracking position in the space of the HMD tracking camera
             Position position_cm = 4;
+            
+            // USB device VID/PID
+            int32 vendorID = 5;
+            int32 productID = 6;
+            
+            // Number of button elements belonging to the device
+            int32 numButtons = 7;
+                                    
+            // Array[numAxes] of values representing the current state of each axis, in the range [0,255]
+            repeated int32 axisStates = 8;
 
             // Only valid if include_raw_tracker_data=true in START_CONTROLLER_DATA_STREAM request
             message RawTrackerData
@@ -937,7 +957,7 @@ message DeviceOutputDataFrame
                 int32 valid_tracker_count= 5;
                 Position multicam_position_cm= 6;
             }
-            RawTrackerData raw_tracker_data = 5;
+            RawTrackerData raw_tracker_data = 9;
 
             // Only valid if include_physics_data=true in START_CONTROLLER_DATA_STREAM request
             message PhysicsData
@@ -945,7 +965,7 @@ message DeviceOutputDataFrame
                 FloatVector velocity_cm_per_sec= 1;
                 FloatVector acceleration_cm_per_sec_sqr= 2;
             }
-            PhysicsData physics_data = 6;
+            PhysicsData physics_data = 10;
         }
         VirtualControllerState virtualcontroller_state = 9;        
     }

--- a/src/psmoveservice/Device/Interface/DeviceInterface.h
+++ b/src/psmoveservice/Device/Interface/DeviceInterface.h
@@ -251,6 +251,9 @@ struct CommonDeviceState
         case VirtualHMD:
             result = "VirtualHMD";
             break;
+        case VirtualController:
+            result = "VirtualController";
+            break;
         default:
             result = "UNKNOWN";
         }

--- a/src/psmoveservice/Device/Manager/ControllerManager.cpp
+++ b/src/psmoveservice/Device/Manager/ControllerManager.cpp
@@ -198,6 +198,12 @@ int ControllerManager::getListUpdatedResponseType()
 	return PSMoveProtocol::Response_ResponseType_CONTROLLER_LIST_UPDATED;
 }
 
+int
+ControllerManager::getGamepadCount() const
+{
+    return gamepad_api_enabled ? Gamepad_numDevices() : 0;
+}
+
 void
 ControllerManager::setControllerRumble(
     int controller_id, 

--- a/src/psmoveservice/Device/Manager/ControllerManager.h
+++ b/src/psmoveservice/Device/Manager/ControllerManager.h
@@ -54,6 +54,8 @@ public:
         return ControllerManager::k_max_devices;
     }
 
+    int getGamepadCount() const;
+
     inline std::string getCachedBluetoothHostAddress() const
     {
         return m_bluetooth_host_address;

--- a/src/psmoveservice/Device/Manager/DeviceManager.cpp
+++ b/src/psmoveservice/Device/Manager/DeviceManager.cpp
@@ -33,6 +33,8 @@ static const int k_default_hmd_poll_interval= 2; // ms
 class DeviceManagerConfig : public PSMoveConfig
 {
 public:
+    static const int CONFIG_VERSION= 1;
+
     DeviceManagerConfig(const std::string &fnamebase = "DeviceManagerConfig")
         : PSMoveConfig(fnamebase)
         , controller_reconnect_interval(k_default_controller_reconnect_interval)
@@ -41,7 +43,7 @@ public:
         , tracker_poll_interval(k_default_tracker_poll_interval)
         , hmd_reconnect_interval(k_default_hmd_reconnect_interval)
         , hmd_poll_interval(k_default_hmd_poll_interval)
-		, gamepad_api_enabled(false)
+		, gamepad_api_enabled(true)
 		, platform_api_enabled(true)
     {};
 
@@ -50,6 +52,7 @@ public:
     {
         boost::property_tree::ptree pt;
     
+        pt.put("version", DeviceManagerConfig::CONFIG_VERSION);
         pt.put("controller_reconnect_interval", controller_reconnect_interval);
         pt.put("controller_poll_interval", controller_poll_interval);
         pt.put("tracker_reconnect_interval", tracker_reconnect_interval);
@@ -65,16 +68,28 @@ public:
     void
     ptree2config(const boost::property_tree::ptree &pt)
     {
-        controller_reconnect_interval = pt.get<int>("controller_reconnect_interval", k_default_controller_reconnect_interval);
-        controller_poll_interval = pt.get<int>("controller_poll_interval", k_default_controller_poll_interval);
-        tracker_reconnect_interval = pt.get<int>("tracker_reconnect_interval", k_default_tracker_reconnect_interval);
-        tracker_poll_interval = pt.get<int>("tracker_poll_interval", k_default_tracker_poll_interval);
-        hmd_reconnect_interval = pt.get<int>("hmd_reconnect_interval", k_default_hmd_reconnect_interval);
-        hmd_poll_interval = pt.get<int>("hmd_poll_interval", k_default_hmd_poll_interval);
-		gamepad_api_enabled = pt.get<bool>("gamepad_api_enabled", gamepad_api_enabled);
-		platform_api_enabled = pt.get<bool>("platform_api_enabled", platform_api_enabled);
+        version = pt.get<int>("version", 0);
+
+        if (version == ControllerManagerConfig::CONFIG_VERSION)
+        {
+            controller_reconnect_interval = pt.get<int>("controller_reconnect_interval", k_default_controller_reconnect_interval);
+            controller_poll_interval = pt.get<int>("controller_poll_interval", k_default_controller_poll_interval);
+            tracker_reconnect_interval = pt.get<int>("tracker_reconnect_interval", k_default_tracker_reconnect_interval);
+            tracker_poll_interval = pt.get<int>("tracker_poll_interval", k_default_tracker_poll_interval);
+            hmd_reconnect_interval = pt.get<int>("hmd_reconnect_interval", k_default_hmd_reconnect_interval);
+            hmd_poll_interval = pt.get<int>("hmd_poll_interval", k_default_hmd_poll_interval);
+		    gamepad_api_enabled = pt.get<bool>("gamepad_api_enabled", gamepad_api_enabled);
+		    platform_api_enabled = pt.get<bool>("platform_api_enabled", platform_api_enabled);
+        }
+        else
+        {
+            SERVER_LOG_WARNING("DeviceManagerConfig") <<
+                "Config version " << version << " does not match expected version " <<
+                DeviceManagerConfig::CONFIG_VERSION << ", Using defaults.";
+        }
     }
 
+    int version;
     int controller_reconnect_interval;
     int controller_poll_interval;
     int tracker_reconnect_interval;

--- a/src/psmoveservice/Device/View/ServerControllerView.cpp
+++ b/src/psmoveservice/Device/View/ServerControllerView.cpp
@@ -1638,7 +1638,7 @@ static void generate_virtual_controller_data_frame_for_stream(
     if (controller_state != nullptr)
     {        
         assert(controller_state->DeviceType == CommonDeviceState::VirtualController);
-        const PSMoveControllerState * psmove_state= static_cast<const PSMoveControllerState *>(controller_state);
+        const VirtualControllerState * virtual_controller_state= static_cast<const VirtualControllerState *>(controller_state);
 
         virtual_controller_data_frame->set_iscurrentlytracking(controller_view->getIsCurrentlyTracking());
         virtual_controller_data_frame->set_istrackingenabled(controller_view->getIsTrackingEnabled());
@@ -1655,6 +1655,18 @@ static void generate_virtual_controller_data_frame_for_stream(
             virtual_controller_data_frame->mutable_position_cm()->set_x(0);
             virtual_controller_data_frame->mutable_position_cm()->set_y(0);
             virtual_controller_data_frame->mutable_position_cm()->set_z(0);
+        }
+
+        // Always send the gamepad data
+        controller_data_frame->set_button_down_bitmask(controller_state->AllButtons);
+
+        virtual_controller_data_frame->set_numbuttons(virtual_controller_state->numButtons);
+        virtual_controller_data_frame->set_productid(virtual_controller_state->productID);
+        virtual_controller_data_frame->set_vendorid(virtual_controller_state->vendorID);
+
+        for (int axisIndex = 0; axisIndex < virtual_controller_state->numAxes; ++axisIndex)
+        {
+            virtual_controller_data_frame->add_axisstates(virtual_controller_state->axisStates[axisIndex]);
         }
 
         // If requested, get the raw tracker data for the controller


### PR DESCRIPTION
There are now two new options in the virtual controller settings UI:
  * Assigned Gamepad - Allows you to assign a gamepad to a virtual controller
  * Test Buttons - A screen for testing buttons and axis on a controller

![virtualgamepad](https://user-images.githubusercontent.com/16793853/27020238-4378785e-4ef4-11e7-9d1a-89021ca45e5d.jpg)

The "Test Buttons" screen is available for all controller types (PSMove, PSNavi, DualShock 4, and Virtual Controllers). For the PSMove controller it looks like this:

![psmovebuttons](https://user-images.githubusercontent.com/16793853/27020293-aed18fa0-4ef4-11e7-93c1-a1b54a64fb53.jpg)

For virtual controllers, buttons are mapped from the selected gamepad connected to the PC. The gamepad must support the XInput API on Win10 (xbox 360 controllers being one example). Since there is no context for what the buttons and axes are from the gamepad API you'll just get a generic button and axis list. It's up to users of the PSMove client API to map buttons to a desired action. 

![virtualcontrollerbuttons](https://user-images.githubusercontent.com/16793853/27020340-21de820a-4ef5-11e7-84a4-3d9d2bf8e0cf.jpg)

The key take away from this is that it's now possible to turn a wireless xbox 360 controller into a tracked VR controller! Of course the orientation is always forward, but that's a problem I think I can kind of solve with some basic two-bone IK.

NOTE: Make sure you have "gamepad_api_enabled" set to "true" in DeviceManagerConfig.json to test this.
NOTE: XBox360 controllers will also show up as a Navi controller due to how ScpService re-maps Navi controllers onto the xinput API. It doesn't really hurt anything, but it's just confusing in the UI.