### PR TITLE
Fixing tracker pose calibration to support calibration with HMDs

### DIFF
--- a/src/psmoveclient/PSMoveClient_CAPI.cpp
+++ b/src/psmoveclient/PSMoveClient_CAPI.cpp
@@ -773,6 +773,9 @@ PSMResult PSM_GetIsControllerStable(PSMControllerID controller_id, bool *out_is_
 				result= PSMResult_Success;
             } break;
         case PSMController_Virtual:
+            // Virtual controller can never be stable
+            *out_is_stable = false;
+            result= PSMResult_Success;
             break;
         }
     }
@@ -1421,7 +1424,8 @@ PSMResult PSM_GetIsHmdStable(PSMHmdID hmd_id, bool *out_is_stable)
             } break;
         case PSMHmd_Virtual:
             {
-				*out_is_stable = true;
+                // Virtual HMD can never be stable
+				*out_is_stable = false;
 
 				result= PSMResult_Success;
             } break;

--- a/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.cpp
+++ b/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.cpp
@@ -63,12 +63,22 @@ AppStage_ComputeTrackerPoses::~AppStage_ComputeTrackerPoses()
     delete m_pCalibrateWithMat;
 }
 
-void AppStage_ComputeTrackerPoses::enterStageAndCalibrateTrackers(App *app, PSMControllerID reqeusted_controller_id)
+void AppStage_ComputeTrackerPoses::enterStageAndCalibrateTrackersWithController(App *app, PSMControllerID reqeusted_controller_id)
 {
     AppStage_ComputeTrackerPoses *appStage= app->getAppStage<AppStage_ComputeTrackerPoses>();
     appStage->m_bSkipCalibration = false;
     appStage->m_overrideControllerId = reqeusted_controller_id;
     appStage->m_overrideHmdId = -1;
+
+    app->setAppStage(AppStage_ComputeTrackerPoses::APP_STAGE_NAME);
+}
+
+void AppStage_ComputeTrackerPoses::enterStageAndCalibrateTrackersWithHMD(class App *app, PSMHmdID reqeusted_hmd_id)
+{
+    AppStage_ComputeTrackerPoses *appStage = app->getAppStage<AppStage_ComputeTrackerPoses>();
+    appStage->m_bSkipCalibration = false;
+    appStage->m_overrideControllerId = -1;
+    appStage->m_overrideHmdId = reqeusted_hmd_id;
 
     app->setAppStage(AppStage_ComputeTrackerPoses::APP_STAGE_NAME);
 }
@@ -904,6 +914,11 @@ PSMTracker *AppStage_ComputeTrackerPoses::get_render_tracker_view() const
 PSMController *AppStage_ComputeTrackerPoses::get_calibration_controller_view() const
 {
     return (m_controllerViews.size() > 0) ? m_controllerViews.begin()->second.controllerView : nullptr;
+}
+
+PSMHeadMountedDisplay *AppStage_ComputeTrackerPoses::get_calibration_hmd_view() const
+{
+    return (m_hmdViews.size() > 0) ? m_hmdViews.begin()->second.hmdView : nullptr;
 }
 
 void AppStage_ComputeTrackerPoses::release_devices()

--- a/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.h
+++ b/src/psmoveconfigtool/AppStage_ComputeTrackerPoses.h
@@ -45,7 +45,8 @@ public:
     AppStage_ComputeTrackerPoses(class App *app);
     ~AppStage_ComputeTrackerPoses();
 
-    static void enterStageAndCalibrateTrackers(class App *app, PSMControllerID reqeusted_controller_id=-1);
+    static void enterStageAndCalibrateTrackersWithController(class App *app, PSMControllerID reqeusted_controller_id=-1);
+    static void enterStageAndCalibrateTrackersWithHMD(class App *app, PSMHmdID reqeusted_hmd_id=-1);
     static void enterStageAndTestTrackers(class App *app, PSMControllerID reqeusted_controller_id=-1, PSMHmdID requested_hmd_id=-1);
 
 	inline void set_tracker_id(int reqeusted_tracker_id)
@@ -107,6 +108,7 @@ protected:
     int get_render_tracker_index() const;
     PSMTracker *get_render_tracker_view() const;
 	PSMController *get_calibration_controller_view() const;
+    PSMHeadMountedDisplay *get_calibration_hmd_view() const;
 
     void request_controller_list();
     static void handle_controller_list_response(

--- a/src/psmoveconfigtool/AppStage_TrackerSettings.cpp
+++ b/src/psmoveconfigtool/AppStage_TrackerSettings.cpp
@@ -168,7 +168,7 @@ void AppStage_TrackerSettings::renderUI()
     const char *k_window_title = "Tracker Settings";
     const ImGuiWindowFlags window_flags =
         ImGuiWindowFlags_ShowBorders |
-        ImGuiWindowFlags_NoResize |
+        ImGuiWindowFlags_AlwaysAutoResize |
         ImGuiWindowFlags_NoMove |
         ImGuiWindowFlags_NoScrollbar |
         ImGuiWindowFlags_NoCollapse;
@@ -178,7 +178,7 @@ void AppStage_TrackerSettings::renderUI()
     case eTrackerMenuState::idle:
     {
         ImGui::SetNextWindowPosCenter();
-        ImGui::SetNextWindowSize(ImVec2(300, 400));
+        //ImGui::SetNextWindowSize(ImVec2(300, 400));
         ImGui::Begin(k_window_title, nullptr, window_flags);
 
         //###HipsterSloth $TODO The tracker restart currently takes longer than it does
@@ -361,16 +361,16 @@ void AppStage_TrackerSettings::renderUI()
                             m_app->setAppStage(AppStage_ColorCalibration::APP_STAGE_NAME);
                         }
 
-                        if (ImGui::Button("Compute Tracker Poses"))
+                        if (ImGui::Button("Compute Tracker Poses Using Controller"))
                         {
-                            AppStage_ComputeTrackerPoses::enterStageAndCalibrateTrackers(m_app, controllerID);
+                            AppStage_ComputeTrackerPoses::enterStageAndCalibrateTrackersWithController(m_app, controllerID);
                         }
 
                     }
                     else
                     {
                         ImGui::TextDisabled("Calibrate Controller Tracking Colors");
-                        ImGui::TextDisabled("Compute Tracker Poses");
+                        ImGui::TextDisabled("Compute Tracker Poses Using Controller");
                     }
 
                     if (ImGui::Button("Test Tracking Pose##ControllerTrackingPose") || m_gotoTestControllerTracking)
@@ -465,10 +465,24 @@ void AppStage_TrackerSettings::renderUI()
 
                         m_app->setAppStage(AppStage_ColorCalibration::APP_STAGE_NAME);
                     }
+
+                    if (m_selectedHmdIndex != -1)
+                    {
+                        const AppStage_TrackerSettings::HMDInfo &hmdInfo = m_hmdInfos[m_selectedHmdIndex];
+
+                        if (hmdInfo.HmdType == PSMHmd_Virtual)
+                        {
+                            if (ImGui::Button("Compute Tracker Poses Using HMD"))
+                            {
+                                AppStage_ComputeTrackerPoses::enterStageAndCalibrateTrackersWithHMD(m_app, hmdID);
+                            }
+                        }
+                    }
                 }
                 else
                 {
                     ImGui::TextDisabled("Calibrate HMD Tracking Colors");
+                    ImGui::TextDisabled("Compute Tracker Poses");
                 }
 
                 if (ImGui::Button("Test Tracking Pose##HMDTrackingPose") || m_gotoTestHmdTracking)

--- a/src/psmoveconfigtool/AppSubStage_CalibrateWithMat.h
+++ b/src/psmoveconfigtool/AppSubStage_CalibrateWithMat.h
@@ -16,8 +16,10 @@ public:
         invalid,
 
         initial,
-        calibrationStepPlacePSMove,
-        calibrationStepRecordPSMove,
+        calibrationStepPlaceController,
+        calibrationStepRecordController,
+        calibrationStepPlaceHMD,
+        calibrationStepRecordHMD,
         calibrationStepComputeTrackerPoses,
 
         calibrateStepSuccess,
@@ -50,9 +52,9 @@ private:
 
     std::chrono::time_point<std::chrono::high_resolution_clock> m_stableStartTime;
     bool m_bIsStable;
-    bool m_bForceControllerStable;
+    bool m_bForceStable;
 
-	struct TrackerRelativePoseStatistics *m_psmoveTrackerPoseStats[PSMOVESERVICE_MAX_TRACKER_COUNT];
+	struct TrackerRelativePoseStatistics *m_deviceTrackerPoseStats[PSMOVESERVICE_MAX_TRACKER_COUNT];
 
     int m_sampleLocationIndex;
 };

--- a/src/psmoveprotocol/ProtocolVersion.h
+++ b/src/psmoveprotocol/ProtocolVersion.h
@@ -12,7 +12,7 @@
 #define PSM_VERSION_MAJOR   9
 #define PSM_VERSION_PHASE   alpha
 #define PSM_VERSION_MINOR   8
-#define PSM_VERSION_RELEASE 5
+#define PSM_VERSION_RELEASE 6
 #define PSM_VERSION_HOTFIX  0
 
 /// "Product.Major-Phase Minor.Release"


### PR DESCRIPTION
* Useful if you only have a virtual HMD to use
* Don't consider virtual HMDs or virtual Controllers ever stable (always use "Trust me, it's stable button")
* Updating AppSubStage_CalibrateWithMat to work with both controllers and HMDs