### PR TITLE
Assorted virtual controller work related fixes

### DIFF
--- a/src/psmoveconfigtool/AppStage_TrackerSettings.cpp
+++ b/src/psmoveconfigtool/AppStage_TrackerSettings.cpp
@@ -284,7 +284,7 @@ void AppStage_TrackerSettings::renderUI()
         }
         else
         {
-            ImGui::Text("No trackers controllers");
+            ImGui::Text("No trackers");
         }
 
         ImGui::Separator();

--- a/src/psmoveservice/Device/Enumerator/ControllerGamepadEnumerator.cpp
+++ b/src/psmoveservice/Device/Enumerator/ControllerGamepadEnumerator.cpp
@@ -17,6 +17,9 @@
 // -- macros ----
 #define MAX_CONTROLLER_TYPE_INDEX           GET_DEVICE_TYPE_INDEX(CommonDeviceState::SUPPORTED_CONTROLLER_TYPE_COUNT)
 
+//-- Statics
+int ControllerGamepadEnumerator::virtual_controller_count= 0;
+
 // -- globals -----
 struct GamepadAPIDeviceFilter
 {
@@ -123,12 +126,18 @@ static bool is_gamepad_supported(
 				CommonDeviceState::eDeviceType device_type =
 					static_cast<CommonDeviceState::eDeviceType>(CommonDeviceState::Controller + gamepad_type_index);
 
-				if (device_type_filter == device_type || device_type_filter == CommonDeviceState::INVALID_DEVICE_TYPE)
-				{
-					out_device_type= device_type;
-					bIsValidDevice = true;
-					break;
-				}				
+                // Don't enumerate PSNavi controllers when using virtual controllers
+                // (since a PSNavi controller will be considered a kind of virtual controller)
+                if (device_type != CommonDeviceState::PSNavi &&
+                    (device_type == CommonDeviceState::PSNavi && ControllerGamepadEnumerator::virtual_controller_count == 0))
+                {
+				    if (device_type_filter == device_type || device_type_filter == CommonDeviceState::INVALID_DEVICE_TYPE)
+				    {
+					    out_device_type= device_type;
+					    bIsValidDevice = true;
+					    break;
+				    }
+                }
 			}
 		}
 	}

--- a/src/psmoveservice/Device/Enumerator/ControllerGamepadEnumerator.h
+++ b/src/psmoveservice/Device/Enumerator/ControllerGamepadEnumerator.h
@@ -19,6 +19,9 @@ public:
 	int get_product_id() const override;
 	inline int get_contoller_index() const { return m_controllerIndex; }
 
+    // Assigned by the controller manager on startup
+    static int virtual_controller_count;
+
 private:
 	char m_currentUSBPath[256];
 	int m_controllerIndex;

--- a/src/psmoveservice/Device/Manager/ControllerManager.cpp
+++ b/src/psmoveservice/Device/Manager/ControllerManager.cpp
@@ -78,9 +78,10 @@ ControllerManager::startup()
         // Save back out the config in case there were updated defaults
         cfg.save();
 
-        // Copy the virtual controller count into the Virtual controller enumerator static variable.
+        // Copy the virtual controller count into the Virtual and Gamepad controller enumerator's static variable.
         // This breaks the dependency between the Controller Manager and the enumerator.
         VirtualControllerEnumerator::virtual_controller_count= cfg.virtual_controller_count;
+        ControllerGamepadEnumerator::virtual_controller_count= cfg.virtual_controller_count;
 
         // Initialize HIDAPI
         if (hid_init() == -1)


### PR DESCRIPTION
Don't enumerate over PSNavi controllers when virtual controllers are active
* No easy way to distinguish between navi controllers and other XInput controllers
* Navi gets treated as a virtual controller in this case

Fixed typo in Tracker Settings UI