### PR TITLE
Unify some limit variables

### DIFF
--- a/src/psmoveclient/ClientConstants.h
+++ b/src/psmoveclient/ClientConstants.h
@@ -1,6 +1,9 @@
 #ifndef CLIENT_CONSTANTS_H
 #define CLIENT_CONSTANTS_H
 
+//-- includes -----
+#include "../psmoveprotocol/PSMoveProtocolInterface.h"
+
 /** 
 \addtogroup PSMoveClient_CAPI 
 @{ 
@@ -10,15 +13,6 @@
 #define PSMOVESERVICE_DEFAULT_ADDRESS   "localhost"
 #define PSMOVESERVICE_DEFAULT_PORT      "9512"
 #define PSM_DEFAULT_TIMEOUT 1000 // milliseconds
-
-// See ControllerManager.h in PSMoveService
-#define PSMOVESERVICE_MAX_CONTROLLER_COUNT  5
-
-// See TrackerManager.h in PSMoveService
-#define PSMOVESERVICE_MAX_TRACKER_COUNT  8
-
-// See HMDManager.h in PSMoveService
-#define PSMOVESERVICE_MAX_HMD_COUNT  4
 
 // The length of a controller serial string: "xx:xx:xx:xx:xx:xx\0"
 #define PSMOVESERVICE_CONTROLLER_SERIAL_LEN  18

--- a/src/psmoveprotocol/PSMoveProtocolInterface.h
+++ b/src/psmoveprotocol/PSMoveProtocolInterface.h
@@ -7,6 +7,15 @@
 //-- constants -----
 #define MAX_OUTPUT_DATA_FRAME_MESSAGE_SIZE 500
 #define MAX_INPUT_DATA_FRAME_MESSAGE_SIZE 64
+
+// See ControllerManager.h in PSMoveService
+#define PSMOVESERVICE_MAX_CONTROLLER_COUNT  5
+
+// See TrackerManager.h in PSMoveService
+#define PSMOVESERVICE_MAX_TRACKER_COUNT  8
+
+// See HMDManager.h in PSMoveService
+#define PSMOVESERVICE_MAX_HMD_COUNT  4
  
 //-- pre-declarations -----
 namespace PSMoveProtocol

--- a/src/psmoveservice/Device/Manager/ControllerManager.h
+++ b/src/psmoveservice/Device/Manager/ControllerManager.h
@@ -48,7 +48,7 @@ public:
         return cfg;
     }
 
-    static const int k_max_devices = 5;
+    static const int k_max_devices = PSMOVESERVICE_MAX_CONTROLLER_COUNT;
     int getMaxDevices() const override
     {
         return ControllerManager::k_max_devices;

--- a/src/psmoveservice/Device/Manager/DeviceTypeManager.h
+++ b/src/psmoveservice/Device/Manager/DeviceTypeManager.h
@@ -3,6 +3,7 @@
 
 //-- includes -----
 #include "DevicePlatformInterface.h"
+#include "PSMoveProtocolInterface.h"
 
 #include <memory>
 #include <chrono>

--- a/src/psmoveservice/Device/Manager/HMDManager.h
+++ b/src/psmoveservice/Device/Manager/HMDManager.h
@@ -40,7 +40,7 @@ public:
 
 	void updateStateAndPredict(TrackerManager* tracker_manager);
 
-    static const int k_max_devices = 4;
+    static const int k_max_devices = PSMOVESERVICE_MAX_HMD_COUNT;
     int getMaxDevices() const override
     {
         return HMDManager::k_max_devices;

--- a/src/psmoveservice/Device/Manager/TrackerManager.h
+++ b/src/psmoveservice/Device/Manager/TrackerManager.h
@@ -78,7 +78,7 @@ public:
 
     void closeAllTrackers();
 
-    static const int k_max_devices = 4;
+    static const int k_max_devices = PSMOVESERVICE_MAX_TRACKER_COUNT;
     int getMaxDevices() const override
     {
         return TrackerManager::k_max_devices;


### PR DESCRIPTION
The tracker limit was independently defined in two locations. Now it is
controlled by just the one variable (PSMOVESERVICE_MAX_TRACKER_COUNT).